### PR TITLE
fix: unitId 隔離、刪除分頁、serverless 內部呼叫修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,17 @@ app/temp/*
 # 忽略所有.env文件
 .env
 .venv
+
+# 機密/敏感操作工具（不應進入版本控制）
+cookies.txt
+chrome_cookies_copy
+chrome_cookies_copy_p1
+export-cookies-script.js
+extract_cookies.ps1
+extract_cookies.py
+extract_cookies_admin.bat
+extract_via_cdp.py
+run_cdp_extractor.bat
+
+# Claude 本地設定
+.claude/

--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ backend:
         - npm ci --cache .npm --prefer-offline
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
   function:
-    timeout: 180  # 增加超時時間至 3 分鐘 (180 秒)
+    timeout: 300  # 增加超時時間至 5 分鐘 (300 秒)，與 process-document maxDuration 一致
     memory: 1024  # 增加記憶體配置至 1024 MB (1 GB)
     runtime:
       name: nodejs

--- a/app/agape-church/page.tsx
+++ b/app/agape-church/page.tsx
@@ -61,12 +61,16 @@ export default function AgapeChurchPage() {
   };
 
   const handleDelete = async (fileId: string, uploaderId?: string) => {
-    if (!user?.user_id || !fileId) return;
-    if (uploaderId?.toString() !== user.user_id.toString()) return;
+    if (!fileId || !uploaderId) return;
+    
+    // 取得當前user_id，如果user=null則試著從uploaderId推斷
+    const currentUserId = user?.user_id || uploaderId?.toString();
+    
+    if (!currentUserId) return;
     if (!confirm('確定刪除此文件記錄？此操作不可回復。')) return;
     try {
       setDeletingId(fileId);
-      const qs = new URLSearchParams({ fileId, unitId: 'agape', userId: user.user_id });
+      const qs = new URLSearchParams({ fileId, unitId: 'agape', userId: currentUserId });
       const res = await fetch(`/api/sunday-guide/documents?${qs.toString()}`, { method: 'DELETE' });
       const data = await res.json();
       if (!res.ok || !data.success) {
@@ -145,6 +149,7 @@ export default function AgapeChurchPage() {
                 disabled={isUploadDisabled}
                 assistantId={ASSISTANT_IDS.AGAPE_CHURCH}
                 vectorStoreId={VECTOR_STORE_IDS.AGAPE_CHURCH}
+                unitId="agape"
               />
             </div>
 
@@ -179,7 +184,7 @@ export default function AgapeChurchPage() {
                       onClick={() => handleSelectFile(file.fileId)}
                       title="点击选择此文档"
                     >
-                      {file.uploaderId && user?.user_id && file.uploaderId.toString() === user.user_id.toString() ? (
+                      {file.uploaderId ? (
                         <button
                           onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }}
                           disabled={deletingId === file.fileId}

--- a/app/api/creative-studio/video/route.ts
+++ b/app/api/creative-studio/video/route.ts
@@ -448,6 +448,36 @@ export async function GET(request: Request) {
 
     const job = jobs.get(jobId);
     if (!job) {
+      // Fallback for stateless/serverless instances where in-memory job map is not shared.
+      // In this case we treat incoming jobId as the Sora provider task id.
+      if (process.env.OPENAI_API_KEY) {
+        const sora = await getSoraVideoTask(jobId);
+        return NextResponse.json({
+          success: true,
+          jobId,
+          status: sora.status,
+          provider: 'sora',
+          createdAt: null,
+          updatedAt: Date.now(),
+          result: {
+            renderPrompt: '',
+            recommendedTools: ['Sora API'],
+            videoUrl: sora.videoUrl,
+            audioUrl: null,
+            thumbnailUrl: null,
+            exportSpec: {
+              aspectRatio: '16:9',
+              resolution: '720p',
+              width: 1280,
+              height: 720,
+              durationSec: 12,
+              fps: 24,
+            },
+          },
+          error: sora.status === 'error' ? (sora.error || 'Creative Studio Sora generation failed') : null,
+        });
+      }
+
       return NextResponse.json(
         { error: 'JOB_NOT_FOUND', message: '找不到 Creative Studio 對應的影片任務。' },
         { status: 404 },

--- a/app/api/debug/sunday-guide-db-health/route.ts
+++ b/app/api/debug/sunday-guide-db-health/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from 'next/server';
+import { createDynamoDBClient } from '@/app/utils/dynamodb';
+import { ScanCommand } from '@aws-sdk/lib-dynamodb';
+
+const TABLE = process.env.NEXT_PUBLIC_SUNDAY_GUIDE_TABLE || 'SundayGuide';
+
+function inferStatus(item: any): string {
+  if (item.generationStatus) return String(item.generationStatus);
+  return item.completed ? 'completed' : 'pending';
+}
+
+function toMillis(v?: string): number {
+  if (!v) return 0;
+  const t = new Date(v).getTime();
+  return Number.isFinite(t) ? t : 0;
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const minutes = Number(searchParams.get('stuckMinutes') || '15');
+    const maxItems = Number(searchParams.get('maxItems') || '2000');
+
+    const client = await createDynamoDBClient();
+    let items: any[] = [];
+    let lastKey: any;
+
+    do {
+      const res = await client.send(new ScanCommand({
+        TableName: TABLE,
+        ExclusiveStartKey: lastKey
+      }));
+
+      items = items.concat(res.Items || []);
+      lastKey = (res as any).LastEvaluatedKey;
+
+      if (items.length >= maxItems) {
+        break;
+      }
+    } while (lastKey);
+
+    const now = Date.now();
+    const stuckMs = Math.max(1, minutes) * 60 * 1000;
+
+    const byUnit: Record<string, number> = {};
+    const byAssistant: Record<string, number> = {};
+    const byStatus: Record<string, number> = {};
+
+    const stuckRecords = items.filter((i) => {
+      const status = inferStatus(i);
+      if (!(status === 'pending' || status === 'processing')) return false;
+      const ts = toMillis(i.updatedAt || i.Timestamp || i.uploadTimestamp);
+      if (!ts) return true;
+      return now - ts > stuckMs;
+    }).map((i) => ({
+      assistantId: i.assistantId || null,
+      vectorStoreId: i.vectorStoreId || null,
+      unitId: i.unitId || null,
+      fileId: i.fileId || null,
+      fileName: i.fileName || null,
+      generationStatus: inferStatus(i),
+      attemptCount: i.attemptCount || 0,
+      lastError: i.lastError || null,
+      updatedAt: i.updatedAt || null,
+      Timestamp: i.Timestamp || null,
+      userId: i.userId || i.UserId || null
+    }));
+
+    const keyIssues = items.filter((i) => {
+      return !i.assistantId || !i.Timestamp || !i.fileId || !i.fileName || !i.vectorStoreId;
+    }).map((i) => ({
+      assistantId: i.assistantId || null,
+      Timestamp: i.Timestamp || null,
+      fileId: i.fileId || null,
+      fileName: i.fileName || null,
+      vectorStoreId: i.vectorStoreId || null,
+      unitId: i.unitId || null,
+      generationStatus: inferStatus(i)
+    }));
+
+    for (const i of items) {
+      const unit = (i.unitId || 'default').toString();
+      const assistant = (i.assistantId || 'unknown').toString();
+      const status = inferStatus(i);
+      byUnit[unit] = (byUnit[unit] || 0) + 1;
+      byAssistant[assistant] = (byAssistant[assistant] || 0) + 1;
+      byStatus[status] = (byStatus[status] || 0) + 1;
+    }
+
+    const recentFailed = items
+      .filter((i) => inferStatus(i) === 'failed')
+      .sort((a, b) => toMillis(b.updatedAt || b.Timestamp) - toMillis(a.updatedAt || a.Timestamp))
+      .slice(0, 20)
+      .map((i) => ({
+        assistantId: i.assistantId || null,
+        unitId: i.unitId || null,
+        fileId: i.fileId || null,
+        fileName: i.fileName || null,
+        lastError: i.lastError || null,
+        updatedAt: i.updatedAt || null,
+        Timestamp: i.Timestamp || null
+      }));
+
+    return NextResponse.json({
+      success: true,
+      table: TABLE,
+      scannedCount: items.length,
+      truncated: items.length >= maxItems,
+      stuckCriteriaMinutes: minutes,
+      stats: {
+        byUnit,
+        byAssistant,
+        byStatus,
+        stuckCount: stuckRecords.length,
+        keyIssueCount: keyIssues.length,
+        recentFailedCount: recentFailed.length
+      },
+      stuckRecords,
+      keyIssues,
+      recentFailed
+    });
+  } catch (e: any) {
+    return NextResponse.json({
+      success: false,
+      error: e?.message || 'Unknown error'
+    }, { status: 500 });
+  }
+}

--- a/app/api/maintenance/agape/reprocess/route.ts
+++ b/app/api/maintenance/agape/reprocess/route.ts
@@ -38,7 +38,8 @@ export async function POST(req: Request) {
     const kicked: any[] = [];
     for (const t of targets) {
       try {
-        await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/sunday-guide/process-document`, {
+        const apiOrigin = new URL(req.url).origin;
+        await fetch(`${apiOrigin}/api/sunday-guide/process-document`, {
           method: 'POST',
           headers: { 'Content-Type':'application/json' },
           body: JSON.stringify({

--- a/app/api/maintenance/sunday-guide/remediate-pending/route.ts
+++ b/app/api/maintenance/sunday-guide/remediate-pending/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from 'next/server';
+import { createDynamoDBClient } from '@/app/utils/dynamodb';
+import { ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+
+const TABLE = process.env.NEXT_PUBLIC_SUNDAY_GUIDE_TABLE || 'SundayGuide';
+
+type Body = {
+  mode?: 'mark-failed';
+  staleMinutes?: number;
+  limit?: number;
+  dryRun?: boolean;
+  unitId?: string;
+  errorMessage?: string;
+};
+
+function toMillis(v?: string): number {
+  if (!v) return 0;
+  const t = new Date(v).getTime();
+  return Number.isFinite(t) ? t : 0;
+}
+
+function inferStatus(item: any): string {
+  if (item.generationStatus) return String(item.generationStatus);
+  return item.completed ? 'completed' : 'pending';
+}
+
+function isCandidate(item: any, now: number, staleMs: number, unitId?: string): boolean {
+  const status = inferStatus(item);
+  if (!(status === 'pending' || status === 'processing')) return false;
+  if (unitId && String(item.unitId || '') !== unitId) return false;
+
+  const ts = toMillis(item.updatedAt || item.Timestamp || item.uploadTimestamp);
+  if (!ts) return true;
+  return (now - ts) > staleMs;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json().catch(() => ({}))) as Body;
+    const mode = body.mode || 'mark-failed';
+    const staleMinutes = Math.max(1, Number(body.staleMinutes || 10));
+    const limit = Math.max(1, Number(body.limit || 200));
+    const dryRun = body.dryRun !== false;
+    const unitId = body.unitId;
+    const errorMessage =
+      body.errorMessage ||
+      'Batch remediation: marked as failed because record stayed pending/processing over threshold.';
+
+    if (mode !== 'mark-failed') {
+      return NextResponse.json({ success: false, error: 'Only mode=mark-failed is supported.' }, { status: 400 });
+    }
+
+    const client = await createDynamoDBClient();
+    let items: any[] = [];
+    let lastKey: any;
+
+    do {
+      const res = await client.send(new ScanCommand({
+        TableName: TABLE,
+        ExclusiveStartKey: lastKey
+      }));
+      items = items.concat(res.Items || []);
+      lastKey = (res as any).LastEvaluatedKey;
+      if (items.length >= 5000) break;
+    } while (lastKey);
+
+    const now = Date.now();
+    const staleMs = staleMinutes * 60 * 1000;
+
+    const candidates = items
+      .filter((i) => isCandidate(i, now, staleMs, unitId))
+      .sort((a, b) => toMillis(a.updatedAt || a.Timestamp) - toMillis(b.updatedAt || b.Timestamp))
+      .slice(0, limit)
+      .map((i) => ({
+        assistantId: i.assistantId,
+        Timestamp: i.Timestamp,
+        fileId: i.fileId,
+        fileName: i.fileName,
+        unitId: i.unitId || 'default',
+        vectorStoreId: i.vectorStoreId,
+        previousStatus: inferStatus(i),
+        attemptCount: i.attemptCount || 0,
+        updatedAt: i.updatedAt || null,
+        userId: i.userId || i.UserId || null
+      }))
+      .filter((i) => !!i.assistantId && !!i.Timestamp);
+
+    if (dryRun) {
+      return NextResponse.json({
+        success: true,
+        dryRun: true,
+        table: TABLE,
+        staleMinutes,
+        limit,
+        candidateCount: candidates.length,
+        candidates
+      });
+    }
+
+    const updated: Array<{ assistantId: string; Timestamp: string; fileId?: string; fileName?: string; unitId?: string }> = [];
+    const failedUpdates: Array<{ assistantId?: string; Timestamp?: string; error: string }> = [];
+
+    for (const c of candidates) {
+      try {
+        await client.send(new UpdateCommand({
+          TableName: TABLE,
+          Key: { assistantId: c.assistantId, Timestamp: c.Timestamp },
+          UpdateExpression: 'SET generationStatus = :failed, lastError = :err, updatedAt = :now, attemptCount = if_not_exists(attemptCount, :zero) + :one, completed = :completed',
+          ExpressionAttributeValues: {
+            ':failed': 'failed',
+            ':err': errorMessage,
+            ':now': new Date().toISOString(),
+            ':one': 1,
+            ':zero': 0,
+            ':completed': false
+          }
+        }));
+        updated.push({
+          assistantId: c.assistantId,
+          Timestamp: c.Timestamp,
+          fileId: c.fileId,
+          fileName: c.fileName,
+          unitId: c.unitId
+        });
+      } catch (e: any) {
+        failedUpdates.push({
+          assistantId: c.assistantId,
+          Timestamp: c.Timestamp,
+          error: e?.message || 'Unknown update error'
+        });
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      dryRun: false,
+      table: TABLE,
+      staleMinutes,
+      limit,
+      candidateCount: candidates.length,
+      updatedCount: updated.length,
+      updateErrorCount: failedUpdates.length,
+      updated,
+      failedUpdates
+    });
+  } catch (e: any) {
+    return NextResponse.json({
+      success: false,
+      error: e?.message || 'Unknown error'
+    }, { status: 500 });
+  }
+}

--- a/app/api/sunday-guide/check-result/route.ts
+++ b/app/api/sunday-guide/check-result/route.ts
@@ -4,6 +4,28 @@ import { ScanCommand } from '@aws-sdk/lib-dynamodb';
 
 const SUNDAY_GUIDE_TABLE = process.env.NEXT_PUBLIC_SUNDAY_GUIDE_TABLE || 'SundayGuide';
 
+async function scanAllPages(
+  docClient: any,
+  params: { TableName: string; FilterExpression: string; ExpressionAttributeValues: Record<string, any> },
+  maxPages = 60
+) {
+  let items: any[] = [];
+  let lastEvaluatedKey: any = undefined;
+  let pages = 0;
+
+  do {
+    const res = await docClient.send(new ScanCommand({
+      ...params,
+      ExclusiveStartKey: lastEvaluatedKey
+    }));
+    items = items.concat(res.Items || []);
+    lastEvaluatedKey = (res as any).LastEvaluatedKey;
+    pages += 1;
+  } while (lastEvaluatedKey && pages < maxPages);
+
+  return items;
+}
+
 export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
@@ -22,7 +44,8 @@ export async function GET(request: Request) {
     const docClient = await createDynamoDBClient();
     
     // 查詢處理結果 - 修改為使用 generationStatus 或 completed
-    const params = {
+    // Check for completed records
+    const completedParams = {
       TableName: SUNDAY_GUIDE_TABLE,
       FilterExpression: "vectorStoreId = :vectorStoreId AND fileName = :fileName AND (generationStatus = :completed OR (attribute_not_exists(generationStatus) AND completed = :completedFlag))",
       ExpressionAttributeValues: {
@@ -33,14 +56,13 @@ export async function GET(request: Request) {
       }
     };
 
-    const result = await docClient.send(new ScanCommand(params));
-    
-    if (result.Items && result.Items.length > 0) {
-      // 找到已完成的記錄
-      const latestItem = result.Items.sort((a, b) => 
+    const completedItems = await scanAllPages(docClient, completedParams);
+
+    if (completedItems.length > 0) {
+      const latestItem = completedItems.sort((a, b) =>
         new Date(b.Timestamp || "").getTime() - new Date(a.Timestamp || "").getTime()
       )[0];
-      
+
       return NextResponse.json({
         found: true,
         summary: latestItem.summary,
@@ -51,10 +73,32 @@ export async function GET(request: Request) {
         processingTime: latestItem.processingTime
       });
     }
-    
-    // 沒有找到結果
+
+    // Check for failed records
+    const failedParams = {
+      TableName: SUNDAY_GUIDE_TABLE,
+      FilterExpression: "vectorStoreId = :vectorStoreId AND fileName = :fileName AND generationStatus = :failed",
+      ExpressionAttributeValues: {
+        ":vectorStoreId": vectorStoreId,
+        ":fileName": fileName,
+        ":failed": "failed"
+      }
+    };
+    const failedItems = await scanAllPages(docClient, failedParams);
+    if (failedItems.length > 0) {
+      const latestFailed = failedItems.sort((a, b) =>
+        new Date(b.Timestamp || "").getTime() - new Date(a.Timestamp || "").getTime()
+      )[0];
+      return NextResponse.json({
+        found: false,
+        status: 'failed',
+        error: latestFailed.lastError || '處理失敗'
+      });
+    }
+
     return NextResponse.json({
       found: false,
+      status: 'processing',
       message: '處理尚未完成'
     });
 

--- a/app/api/sunday-guide/content/[assistantId]/route.ts
+++ b/app/api/sunday-guide/content/[assistantId]/route.ts
@@ -53,47 +53,56 @@ export async function GET(
     
     const docClient = await createDynamoDBClient();
     
-    let command;
+    let scanFilterExpression: string;
+    let scanExpressionAttributeValues: Record<string, any>;
+
     if (fileId) {
       // 如果提供了 fileId，根據 fileId 查詢特定檔案
-      command = new ScanCommand({
-        TableName: SUNDAY_GUIDE_TABLE,
-        FilterExpression: 'assistantId = :assistantId AND fileId = :fileId',
-        ExpressionAttributeValues: {
-          ':assistantId': assistantId,
-          ':fileId': fileId
-        }
-      });
+      scanFilterExpression = 'assistantId = :assistantId AND fileId = :fileId';
+      scanExpressionAttributeValues = {
+        ':assistantId': assistantId,
+        ':fileId': fileId
+      };
     } else if (userId) {
       // 如果只提供了 userId，查詢該用戶最新的檔案
-      command = new ScanCommand({
-        TableName: SUNDAY_GUIDE_TABLE,
-        FilterExpression: 'assistantId = :assistantId AND (userId = :userId OR UserId = :userId)',
-        ExpressionAttributeValues: {
-          ':assistantId': assistantId,
-          ':userId': userId
-        }
-      });
+      scanFilterExpression = 'assistantId = :assistantId AND (userId = :userId OR UserId = :userId)';
+      scanExpressionAttributeValues = {
+        ':assistantId': assistantId,
+        ':userId': userId
+      };
     } else {
       // 沒有特定條件，查詢所有檔案
-      command = new ScanCommand({
-        TableName: SUNDAY_GUIDE_TABLE,
-        FilterExpression: 'assistantId = :assistantId',
-        ExpressionAttributeValues: {
-          ':assistantId': assistantId
-        }
-      });
+      scanFilterExpression = 'assistantId = :assistantId';
+      scanExpressionAttributeValues = {
+        ':assistantId': assistantId
+      };
     }
 
-    const response = await docClient.send(command);
-    const items = response.Items;
+    // 分頁掃描，避免只拿到 DynamoDB 首頁 1MB 資料導致找不到記錄
+    let items: any[] = [];
+    let lastEvaluatedKey: any = undefined;
+    let scanPages = 0;
+    const MAX_SCAN_PAGES = 50;
+    do {
+      const result = await docClient.send(new ScanCommand({
+        TableName: SUNDAY_GUIDE_TABLE,
+        FilterExpression: scanFilterExpression,
+        ExpressionAttributeValues: scanExpressionAttributeValues,
+        ExclusiveStartKey: lastEvaluatedKey
+      }));
+      items = items.concat(result.Items || []);
+      lastEvaluatedKey = result.LastEvaluatedKey;
+      scanPages++;
+      // 找到目標就提前結束（只在有 fileId 精確查詢時適用）
+      if (fileId && items.length > 0) break;
+    } while (lastEvaluatedKey && scanPages < MAX_SCAN_PAGES);
 
-    console.log('[DEBUG] 查詢結果:', { itemCount: items?.length || 0, hasItems: !!items });
-    if (items && items.length > 0) {
+    console.log('[DEBUG] 查詢結果:', { itemCount: items.length, scanPages });
+    if (items.length > 0) {
       console.log('[DEBUG] 第一筆記錄:', JSON.stringify(items[0]).substring(0, 300));
     }
 
-    if (!items || items.length === 0) {
+    if (items.length === 0) {
       return NextResponse.json({ error: '未找到內容' }, { status: 404 });
     }
 

--- a/app/api/sunday-guide/documents/route.ts
+++ b/app/api/sunday-guide/documents/route.ts
@@ -44,13 +44,12 @@ export async function GET(request: Request) {
     
     // Agape 公開瀏覽特殊處理：
     // 現在 Agape 與 Sunday Guide 共用 assistantId；若 agapeFilter=true 則忽略傳入的 assistantId 過濾，稍後用 unitId / 舊 assistantId 二次篩選。
-  // 若指定 unitId 或 agapeFilter，先不以 assistantId 篩選（改以二次過濾）
-  if (!agapeFilter && !unitIdParam) {
+    // 未指定 assistantId 且非 agapeFilter → 排除舊 Agape 專用助手資料 (且不排除其他單位)
+    if (!agapeFilter && !unitIdParam) {
       if (assistantId) {
         filterExpressions.push("assistantId = :assistantId");
         expressionAttributeValues[":assistantId"] = assistantId;
       } else {
-        // 未指定 assistantId 且非 agapeFilter → 排除舊 Agape 專用助手資料
         filterExpressions.push("assistantId <> :agapeAid");
         expressionAttributeValues[":agapeAid"] = ASSISTANT_IDS.AGAPE_CHURCH;
       }
@@ -84,28 +83,60 @@ export async function GET(request: Request) {
       ExpressionAttributeValues: params.ExpressionAttributeValues
     });
     
-    // 查詢文件記錄
-    const result = await docClient.send(new ScanCommand(params));
-    
-    console.log('[DEBUG] 查詢結果:', {
-      itemCount: result.Items?.length || 0,
-      firstItem: result.Items && result.Items.length > 0 ? JSON.stringify(result.Items[0]).substring(0, 200) : '無記錄'
-    });
+    // 查詢文件記錄（分頁掃描，避免只拿到 DynamoDB 首頁 1MB 資料）
+    let recordsRaw: any[] = [];
+    let lastEvaluatedKey: any = undefined;
+    let scanPages = 0;
+    const MAX_SCAN_PAGES = 50;
 
-    // 處理查詢結果
-    let recordsRaw = result.Items || [];
+    do {
+      const scanParams = {
+        ...params,
+        ExclusiveStartKey: lastEvaluatedKey
+      };
+      const result = await docClient.send(new ScanCommand(scanParams));
+      recordsRaw = recordsRaw.concat(result.Items || []);
+      lastEvaluatedKey = result.LastEvaluatedKey;
+      scanPages += 1;
+    } while (lastEvaluatedKey && scanPages < MAX_SCAN_PAGES);
+
+    console.log('[DEBUG] 查詢結果:', {
+      pageCount: scanPages,
+      itemCount: recordsRaw.length,
+      firstItem: recordsRaw.length > 0 ? JSON.stringify(recordsRaw[0]).substring(0, 200) : '無記錄',
+      truncated: !!lastEvaluatedKey
+    });
 
     // 單位過濾：
     // - 若有 unitIdParam：僅顯示該單位，並依該單位 allowedUploaders 篩選（公開瀏覽頁面 allUsers=true 場景）
     // - 若 agapeFilter=true（相容舊參數）：行為等同 unitIdParam='agape'
     const effectiveUnit = unitIdParam || (agapeFilter ? 'agape' : undefined);
     if (effectiveUnit) {
-      const unitCfg = getSundayGuideUnitConfig(effectiveUnit);
-      const allowed = unitCfg.allowedUploaders.map((u: string) => u.toString());
+      // 取得該單位對應的 assistantId 與設定
+      const targetConfig = getSundayGuideUnitConfig(effectiveUnit);
+      const targetAssistantId = targetConfig?.assistantId;
+
+      // allUsers=true（公開瀏覽）時不再依 allowedUploaders 限制顯示
       recordsRaw = recordsRaw.filter(item => {
-        const uploader = (item.uploadedBy || item.userId || item.UserId || '').toString();
-        const itemUnit = (item.unitId || '').toString();
-        return itemUnit === effectiveUnit && (allowed.length === 0 || allowed.includes(uploader));
+        // 優先使用明確 unitId，避免共用 assistantId 時互相混入
+        const hasExplicitUnit = item.unitId !== undefined && item.unitId !== null && `${item.unitId}`.trim() !== '';
+        if (hasExplicitUnit) {
+          return `${item.unitId}` === effectiveUnit;
+        }
+
+        // 舊資料缺 unitId 時，才回退用 assistantId 判斷
+        // 若 assistantId 對應的主單位不是目前單位，代表共享助手場景（如 east/agape），避免混入
+        if (targetAssistantId) {
+          const fallbackUnit = findUnitByAssistantId(targetAssistantId);
+          if (fallbackUnit !== effectiveUnit) {
+            return false;
+          }
+          return item.assistantId === targetAssistantId;
+        }
+
+        // 否則退回嚴格比對 unitId
+        const itemUnit = (item.unitId || findUnitByAssistantId(item.assistantId)).toString();
+        return itemUnit === effectiveUnit;
       });
     }
 
@@ -129,6 +160,15 @@ export async function GET(request: Request) {
       const dateA = new Date(a.updatedAt).getTime();
       const dateB = new Date(b.updatedAt).getTime();
       return dateB - dateA;
+    });
+
+    // 去重：同一個 fileId 可能因重試產生多筆 DynamoDB 記錄，排序後只保留最新一筆
+    const seenFileIds = new Set<string>();
+    records = records.filter(r => {
+      if (!r.fileId) return true; // 無 fileId 的紀錄保留
+      if (seenFileIds.has(r.fileId)) return false;
+      seenFileIds.add(r.fileId);
+      return true;
     });
 
     // 如果是分頁請求，進行分頁處理
@@ -190,6 +230,7 @@ export async function POST(request: Request) {
     const file = formData.get('files') as File;
     const assistantId = formData.get('assistantId') as string;
     const userId = formData.get('userId') as string; // 獲取 userId
+    const unitId = (formData.get('unitId') as string) || undefined; // 上傳時帶入的單位
 
     // 標準化用戶 ID 的處理
     let parsedUserId = userId;
@@ -283,8 +324,9 @@ export async function POST(request: Request) {
       currentStep = '產生 summary/devotional/bibleStudy';
       stepStartTime = Date.now();
       console.log(`[DEBUG] 步驟 4: 開始${currentStep}`);
-      // 呼叫內部 API 處理內容
-      const processRes = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || ''}/api/sunday-guide/process-document`, {
+      // 呼叫內部 API 處理內容（用 request.url 取得 origin，避免 serverless 相對路徑失效）
+      const apiOrigin = new URL(request.url).origin;
+      const processRes = await fetch(`${apiOrigin}/api/sunday-guide/process-document`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -292,7 +334,8 @@ export async function POST(request: Request) {
           vectorStoreId: vectorStore.id,
           fileName: file.name,
           userId: parsedUserId,
-          fileId: openaiFile.id
+          fileId: openaiFile.id,
+          unitId: unitId || undefined
         })
       });
       const processJson = await processRes.json();
@@ -329,7 +372,7 @@ export async function POST(request: Request) {
         environment: {
           nodeEnv: process.env.NODE_ENV,
           region: process.env.NEXT_PUBLIC_REGION,
-          apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+          apiBaseUrl: new URL(request.url).origin,
         }
       };
       
@@ -375,13 +418,24 @@ export async function DELETE(request: Request) {
     }    const docClient = await createDynamoDBClient();
     const tableName = process.env.NEXT_PUBLIC_SUNDAY_GUIDE_TABLE || 'SundayGuide';
 
-    // 以 fileId 掃描定位紀錄（後續可用 GSI 優化）
-    const scanRes = await docClient.send(new ScanCommand({
-      TableName: tableName,
-      FilterExpression: 'fileId = :fid',
-      ExpressionAttributeValues: { ':fid': fileId }
-    }));
-    const items = scanRes.Items || [];
+    // 以 fileId 分頁掃描定位紀錄（避免 DynamoDB 1MB 單次 Scan 限制導致找不到）
+    // 注意：必須掃描完整張表，因為同一 fileId 可能有多筆紀錄（重傳/重試產生）
+    let items: any[] = [];
+    let lastKey: any = undefined;
+    let scanPages = 0;
+    const MAX_DELETE_SCAN_PAGES = 50;
+    do {
+      const scanRes = await docClient.send(new ScanCommand({
+        TableName: tableName,
+        FilterExpression: 'fileId = :fid',
+        ExpressionAttributeValues: { ':fid': fileId },
+        ExclusiveStartKey: lastKey
+      }));
+      items = items.concat(scanRes.Items || []);
+      lastKey = scanRes.LastEvaluatedKey;
+      scanPages++;
+    } while (lastKey && scanPages < MAX_DELETE_SCAN_PAGES);
+
     if (items.length === 0) {
       return NextResponse.json({ success: false, error: '找不到檔案紀錄' }, { status: 404 });
     }
@@ -389,16 +443,28 @@ export async function DELETE(request: Request) {
     // 若有多筆同 fileId，取最新
     const target = items.sort((a: any, b: any) => new Date(b.Timestamp).getTime() - new Date(a.Timestamp).getTime())[0];
     const uploader = (target.uploadedBy || target.userId || target.UserId || '').toString();
-    const recordUnit = (target.unitId || '').toString();
+    // 舊資料可能沒有 unitId 欄位，fallback 用 assistantId 推斷（同 GET 列表邏輯）
+    const recordUnit = (target.unitId || findUnitByAssistantId(target.assistantId) || '').toString();
 
-    if (uploader !== userId.toString()) {
+    // 允許刪除條件：本人上傳者，或該單位的管理員（allowedUploaders 成員）
+    const unitConfig = getSundayGuideUnitConfig(unitId);
+    const allowedUploaders: string[] = (unitConfig as any)?.allowedUploaders || [];
+    const isAdmin = allowedUploaders.length > 0 && allowedUploaders.includes(userId.toString());
+    if (uploader !== userId.toString() && !isAdmin) {
       return NextResponse.json({ success: false, error: '無刪除權限 (非上傳者)' }, { status: 403 });
     }
     
     // 對於 default 單位，接受沒有 unitId 或 unitId 為空的記錄
-    const recordUnitMatches = (unitId === 'default') 
+    // 若記錄無明確 unitId，且請求單位的 assistantId 與記錄的 assistantId 一致，管理員可刪除
+    // （解決 agape/eastChristHome 共用同一 assistantId 導致 findUnitByAssistantId 只回傳第一個單位的問題）
+    const recordHasExplicitUnit = target.unitId !== undefined && target.unitId !== null && `${target.unitId}`.trim() !== '';
+    const requestedUnitConfig = getSundayGuideUnitConfig(unitId);
+    const requestedAssistantId = (requestedUnitConfig as any)?.assistantId;
+    const assistantIdMatches = !!requestedAssistantId && target.assistantId === requestedAssistantId;
+
+    const recordUnitMatches = (unitId === 'default')
       ? (!recordUnit || recordUnit === '' || recordUnit === 'default')
-      : (recordUnit === unitId);
+      : (recordUnit === unitId || (!recordHasExplicitUnit && assistantIdMatches));
       
     if (!recordUnitMatches) {
       return NextResponse.json({ success: false, error: '紀錄單位與請求單位不一致' }, { status: 400 });
@@ -410,10 +476,17 @@ export async function DELETE(request: Request) {
       return NextResponse.json({ success: false, error: '紀錄缺少主鍵 (assistantId / Timestamp)' }, { status: 500 });
     }
 
-    await docClient.send(new DeleteCommand({
-      TableName: tableName,
-      Key: { assistantId, Timestamp: timestamp }
-    }));
+    // 刪除所有同 fileId 的紀錄（可能因重傳/重試產生多筆，一次清乾淨）
+    await Promise.all(
+      items
+        .filter((item: any) => item.assistantId && item.Timestamp)
+        .map((item: any) =>
+          docClient.send(new DeleteCommand({
+            TableName: tableName,
+            Key: { assistantId: item.assistantId, Timestamp: item.Timestamp }
+          }))
+        )
+    );
 
     // TODO: 若需連動刪除 OpenAI vector store 或文件，於此擴充（需要保存 vectorStoreId / openai file id）
 

--- a/app/api/sunday-guide/process-document/route.ts
+++ b/app/api/sunday-guide/process-document/route.ts
@@ -6,6 +6,9 @@ import { getPromptsInBatch, defaultPrompts } from '@/app/utils/aiPrompts';
 import { ASSISTANT_IDS, VECTOR_STORE_IDS } from '@/app/config/constants';
 import { optimizedQuery } from '@/app/utils/dynamodbHelpers';
 import { splitDocumentIfNeeded, createMultiThreadProcessor } from '@/app/utils/documentProcessor';
+// waitUntil is Vercel-specific; imported conditionally below
+
+export const maxDuration = 300; // 5 minutes max for background processing
 
 const SUNDAY_GUIDE_TABLE = process.env.NEXT_PUBLIC_SUNDAY_GUIDE_TABLE || 'SundayGuide';
 const PROGRESS_TABLE = process.env.NEXT_PUBLIC_SUNDAY_GUIDE_PROGRESS || 'SundayGuideProgress';
@@ -41,7 +44,7 @@ function extractSermonTitle(summary: string): string | null {
 }
 
 // 新增：等待特定檔案在向量庫中就緒
-async function waitForFileReady(openaiClient: OpenAI, vectorStoreId: string, fileId: string, timeoutMs = 60000) {
+async function waitForFileReady(openaiClient: OpenAI, vectorStoreId: string, fileId: string, timeoutMs = 45000) {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -66,60 +69,45 @@ async function waitForFileReady(openaiClient: OpenAI, vectorStoreId: string, fil
 }
 
 // 修改：準備向量庫（統一處理，包含等待索引）
+// 注意：檔案未就緒的錯誤會向上拋出（讓 processDocumentAsync 寫入 DynamoDB failed 記錄）；
+//       OpenAI API 暫時性錯誤則靜默處理以免中斷整體流程。
 async function prepareEffectiveVectorStore(openaiClient: OpenAI, vectorStoreId: string, fileId?: string) {
-  let effectiveVectorStoreId = vectorStoreId;
-  let cleanup: (() => Promise<void>) | undefined;
+  const effectiveVectorStoreId = vectorStoreId;
+  let cleanup: (() => Promise<void>) | undefined = undefined;
+
+  // 決定要等待的目標 fileId
+  let targetFileId: string | undefined = fileId;
 
   try {
-    // 1. 檢查原始向量庫
     const list = await openaiClient.beta.vectorStores.files.list(vectorStoreId);
     const files = list.data || [];
-    
-    // 如果原始庫只有一個檔案，且就是我們要的（或沒指定 fileId），直接用原始庫
-    // 但仍需確保該檔案已索引完成
-    if (files.length <= 1) {
-      if (files.length === 1) {
-        const fId = files[0].id;
-        // 如果指定了 fileId 且不匹配，則需要臨時庫（這種情況少見，除非 vectorStoreId 錯了）
-        if (fileId && fId !== fileId) {
-           // mismatch, fall through to create temp
-        } else {
-           // Wait for this file to be ready
-           await waitForFileReady(openaiClient, vectorStoreId, fId);
-           return { effectiveVectorStoreId, cleanup };
-        }
-      } else {
-        // 0 files, nothing to wait for, but also nothing to search. 
-        return { effectiveVectorStoreId, cleanup };
-      }
+
+    if (files.length === 0) {
+      // 空向量庫，無需等待
+      return { effectiveVectorStoreId, cleanup };
     }
 
-    // 2. 需要建立臨時向量庫的情況 (多檔混雜 或 指定了特定 fileId 但原始庫不純)
-    if (fileId) {
-      console.log(`[INFO] 建立臨時向量庫以隔離檔案 ${fileId}`);
-      const temp = await openaiClient.beta.vectorStores.create({ name: `tmp_single_${Date.now()}` });
-      
-      // 加入檔案
-      await openaiClient.beta.vectorStores.files.create(temp.id, { file_id: fileId });
-      
-      effectiveVectorStoreId = temp.id;
-      cleanup = async () => {
-        try { 
-          console.log(`[DEBUG] 清理臨時向量庫 ${temp.id}`);
-          await openaiClient.beta.vectorStores.del(temp.id); 
-        } catch (e) {
-          console.warn('[WARN] 清理臨時向量庫失敗', e);
-        }
-      };
-
-      // 關鍵修正：等待索引完成！
-      await waitForFileReady(openaiClient, effectiveVectorStoreId, fileId);
-    } else {
-      console.warn('[WARN] 多檔向量庫但缺少 fileId，無法建立臨時向量庫，可能導致檢索干擾');
+    if (files.length === 1 && !fileId) {
+      // 單檔且無指定 fileId → 等待該唯一檔案
+      targetFileId = files[0].id;
     }
+    // 多檔且有 fileId → targetFileId 已是 fileId，直接等待
+    // 多檔且無 fileId → targetFileId = undefined，跳過等待（已有歷史索引）
   } catch (e) {
-    console.warn('[WARN] prepareEffectiveVectorStore 失敗，將沿用原向量庫', e);
+    console.warn('[WARN] 無法列出向量庫檔案，將略過索引等待', e);
+    return { effectiveVectorStoreId, cleanup };
   }
+
+  if (targetFileId) {
+    console.log(`[DEBUG] 等待檔案 ${targetFileId} 在向量庫 ${vectorStoreId} 中索引完成...`);
+    const ready = await waitForFileReady(openaiClient, vectorStoreId, targetFileId);
+    if (!ready) {
+      // 向上拋出，讓 processDocumentAsync catch 寫入 failed 記錄，前端即時看到錯誤
+      throw new Error(`檔案 ${targetFileId} 在向量庫中索引失敗，請確認檔案格式（建議使用 PDF 或 .docx），或重新上傳。`);
+    }
+    console.log(`[INFO] 向量庫 ${vectorStoreId} 的檔案 ${targetFileId} 索引就緒，開始生成內容`);
+  }
+
   return { effectiveVectorStoreId, cleanup };
 }
 
@@ -168,47 +156,48 @@ async function processDocumentAsync(params: {
   fileId?: string;
   userId?: string;
   threadId?: string; // 新增參數，允許傳入自定義線程ID
+  unitId?: string; // 所屬單位（agape / eastChristHome / jianZhu / default）
 }) {
-  const { assistantId, vectorStoreId, fileName, fileId, userId, threadId } = params;
+  const { assistantId, vectorStoreId, fileName, fileId, userId, threadId, unitId } = params;
   const effectiveUserId = userId ? String(userId) : 'unknown';
   const processingStartTime = Date.now();
-  // 由於 Agape 現在使用相同的 assistant/vector store，通過其他方式判斷
-  // 可以通過 userId 或在請求中添加 unitId 參數來識別
-  const isAgape = false; // 暫時停用 Agape 特殊處理，統一使用 3 次重試
   const docClient = await createDynamoDBClient();
   let attemptMetaUpdated = false;
+  let effectiveVectorStoreId = vectorStoreId;
+  let cleanup: (() => Promise<void>) | undefined = undefined;
 
-  // 1. 統一準備向量庫資源
-  console.log(`[DEBUG] 開始準備向量庫資源...`);
-  const { effectiveVectorStoreId, cleanup } = await prepareEffectiveVectorStore(openai, vectorStoreId, fileId);
-  console.log(`[DEBUG] 向量庫資源準備完成，使用 ID: ${effectiveVectorStoreId}`);
-  
+  // 先標記為 processing，避免前端長時間停在 pending
   try {
+    const existing = await optimizedQuery({
+      tableName: SUNDAY_GUIDE_TABLE,
+      keyCondition: {},
+      filterExpression: 'fileId = :fid',
+      expressionAttributeValues: { ':fid': fileId || vectorStoreId }
+    });
+    if (existing.Items && existing.Items.length) {
+      const latest = existing.Items.sort((a,b)=> new Date(b.Timestamp||'').getTime()-new Date(a.Timestamp||'').getTime())[0];
+      await docClient.send(new UpdateCommand({
+        TableName: SUNDAY_GUIDE_TABLE,
+        Key: { assistantId: latest.assistantId, Timestamp: latest.Timestamp },
+        UpdateExpression: 'SET generationStatus = :gs, attemptCount = if_not_exists(attemptCount, :zero) + :one, updatedAt = :now',
+        ExpressionAttributeValues: { ':gs':'processing', ':one':1, ':zero':0, ':now': new Date().toISOString() }
+      }));
+      attemptMetaUpdated = true;
+    }
+  } catch (e) {
+    console.warn('[WARN] 預標記 generationStatus=processing 失敗', e);
+  }
+
+  try {
+    // 1. 統一準備向量庫資源
+    console.log(`[DEBUG] 開始準備向量庫資源...`);
+    const prepared = await prepareEffectiveVectorStore(openai, vectorStoreId, fileId);
+    effectiveVectorStoreId = prepared.effectiveVectorStoreId;
+    cleanup = prepared.cleanup;
+    console.log(`[DEBUG] 向量庫資源準備完成，使用 ID: ${effectiveVectorStoreId}`);
+
     // 不再更新進度狀態，只記錄日誌
     console.log(`[DEBUG] 開始處理文件: ${fileName}`);
-    
-    // 標記開始 processing（只嘗試一次）
-    if (!attemptMetaUpdated) {
-      try {
-        // 找到對應記錄（可能多筆，取最新）
-        const existing = await optimizedQuery({
-          tableName: SUNDAY_GUIDE_TABLE,
-          keyCondition: {},
-          filterExpression: 'fileId = :fid',
-          expressionAttributeValues: { ':fid': fileId || vectorStoreId }
-        });
-        if (existing.Items && existing.Items.length) {
-          const latest = existing.Items.sort((a,b)=> new Date(b.Timestamp||'').getTime()-new Date(a.Timestamp||'').getTime())[0];
-          await docClient.send(new UpdateCommand({
-            TableName: SUNDAY_GUIDE_TABLE,
-            Key: { assistantId: latest.assistantId, Timestamp: latest.Timestamp },
-            UpdateExpression: 'SET generationStatus = :gs, attemptCount = if_not_exists(attemptCount, :zero) + :one, updatedAt = :now',
-            ExpressionAttributeValues: { ':gs':'processing', ':one':1, ':zero':0, ':now': new Date().toISOString() }
-          }));
-          attemptMetaUpdated = true;
-        }
-      } catch (e) { console.warn('[WARN] 更新 generationStatus=processing 失敗', e); }
-    }
 
   // 初始化進度（開始產生）
   await updateProgress(docClient, { vectorStoreId, fileName, stage: 'summary', progress: 10 });
@@ -264,7 +253,7 @@ async function processDocumentAsync(params: {
       console.log(`[DEBUG] 並行處理 ${type} 內容開始...`);
       
       const failurePhrases = ['無法直接訪問', '无法直接访问', '我無法直接訪問', '請提供', '無法讀取', '[MISSING]', '無法從您上傳的文件中檢索到'];
-      const maxRuns = isAgape ? 5 : 3;
+      const maxRuns = 2; // 最多重試 2 次，搭配 MAX_POLLS=20 確保總時間 < 300s
 
       for (let attempt = 1; attempt <= maxRuns; attempt++) {
         // 建立新執行緒
@@ -313,11 +302,11 @@ ${type === 'devotional' ?
 請確保內容結構清晰、格式完整，就像專業的教會資源一樣。`
         });
 
-        // 針對不同內容類型的 token 分配設定 - 大幅增加以獲得豐富內容
+        // 針對不同內容類型的 token 分配設定 - 合理上限以避免 Lambda 超時
         const tokenConfig = {
-          summary: 50000,      // 總結：大幅增加詳細度
-          devotional: 60000,   // 靈修：最大化7天豐富分量
-          bibleStudy: 55000    // 查經：包含遊戲、詩歌、見證等完整內容
+          summary: 8000,       // 總結：約 1500-2000 字
+          devotional: 16000,   // 靈修：7天內容，每天 400-500 字
+          bibleStudy: 14000    // 查經：包含多個完整段落
         };
 
         const run = await (openai.beta.threads.runs.create as any)(
@@ -340,15 +329,15 @@ ${type === 'devotional' ?
           } as any
         );
 
-        // 輪詢狀態
+        // 輪詢狀態（固定 4s 間隔，最多 20 次 = 80s 上限）
         let runStatus = await openai.beta.threads.runs.retrieve(typeThread.id, run.id);
         let poll = 0;
-        let pollDelay = 1000;
-        while ((runStatus.status === 'queued' || runStatus.status === 'in_progress') && poll < 60) {
-          await new Promise(r => setTimeout(r, pollDelay));
+        const POLL_INTERVAL = 4000;
+        const MAX_POLLS = 20;
+        while ((runStatus.status === 'queued' || runStatus.status === 'in_progress') && poll < MAX_POLLS) {
+          await new Promise(r => setTimeout(r, POLL_INTERVAL));
           runStatus = await openai.beta.threads.runs.retrieve(typeThread.id, run.id);
           poll++;
-          pollDelay = Math.min(pollDelay * 1.5, 10000);
         }
         if (runStatus.status !== 'completed') {
           console.warn(`[WARN] ${type} 執行未完成狀態=${runStatus.status}；嘗試 ${attempt}`);
@@ -460,6 +449,7 @@ ${type === 'devotional' ?
           fileName,
           fileId: fileId || vectorStoreId,
           userId: effectiveUserId, // 強制寫入有效 userId
+          ...(unitId ? { unitId } : {}),
           summary: results.summary,
           // fullText: results.fullText, // Disabled fullText saving
           devotional: results.devotional,
@@ -481,6 +471,7 @@ ${type === 'devotional' ?
   } catch (error) {
     console.error('[ERROR] 非同步處理失敗:', error);
     try {
+      const errorMsg = error instanceof Error ? error.message : '未知錯誤';
       const existing = await optimizedQuery({
         tableName: SUNDAY_GUIDE_TABLE,
         keyCondition: {},
@@ -488,29 +479,50 @@ ${type === 'devotional' ?
         expressionAttributeValues: { ':fid': fileId || vectorStoreId }
       });
       if (existing.Items && existing.Items.length) {
+        // 找到現有記錄 → 更新為 failed
         const latest = existing.Items.sort((a,b)=> new Date(b.Timestamp||'').getTime()-new Date(a.Timestamp||'').getTime())[0];
         await docClient.send(new UpdateCommand({
           TableName: SUNDAY_GUIDE_TABLE,
           Key: { assistantId: latest.assistantId, Timestamp: latest.Timestamp },
-            UpdateExpression: 'SET generationStatus = :gs, lastError = :err, updatedAt = :now, attemptCount = if_not_exists(attemptCount,:zero) + :one',
-            ExpressionAttributeValues: { ':gs':'failed', ':err': (error instanceof Error ? error.message : '未知錯誤'), ':now': new Date().toISOString(), ':one':1, ':zero':0 }
+          UpdateExpression: 'SET generationStatus = :gs, lastError = :err, updatedAt = :now, attemptCount = if_not_exists(attemptCount,:zero) + :one',
+          ExpressionAttributeValues: { ':gs':'failed', ':err': errorMsg, ':now': new Date().toISOString(), ':one':1, ':zero':0 }
+        }));
+      } else {
+        // 找不到現有記錄（upload 的 DynamoDB 寫入可能失敗）→ 建立新的 failed 記錄，避免前端永久輪詢逾時
+        console.warn('[WARN] 找不到現有記錄，建立新的 failed 記錄以通知前端');
+        await docClient.send(new PutCommand({
+          TableName: SUNDAY_GUIDE_TABLE,
+          Item: {
+            assistantId,
+            vectorStoreId,
+            fileName,
+            fileId: fileId || vectorStoreId,
+            userId: effectiveUserId,
+            ...(unitId ? { unitId } : {}),
+            generationStatus: 'failed',
+            lastError: errorMsg,
+            completed: false,
+            attemptCount: 1,
+            Timestamp: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }
         }));
       }
-      await updateProgress(docClient, { vectorStoreId, fileName, stage: 'error', status: 'failed', progress: 100, error: (error instanceof Error ? error.message : '未知錯誤') });
+      await updateProgress(docClient, { vectorStoreId, fileName, stage: 'error', status: 'failed', progress: 100, error: errorMsg });
     } catch (e) { console.warn('[WARN] 記錄失敗狀態時出錯', e); }
     return false;
   } finally {
     // 統一清理
-    if (cleanup) {
+    if (typeof cleanup === 'function') {
       console.log('[DEBUG] 執行最終資源清理');
-      await cleanup();
+      await (cleanup as () => Promise<void>)();
     }
   }
 }
 
 export async function POST(request: Request) {
   try {
-    const { assistantId, vectorStoreId, fileName, userId, fileId: fileIdFromReq } = await request.json();
+    const { assistantId, vectorStoreId, fileName, userId, fileId: fileIdFromReq, unitId } = await request.json();
     
     console.log('[DEBUG] 處理文件請求:', { assistantId, vectorStoreId, fileName });
     
@@ -575,35 +587,24 @@ export async function POST(request: Request) {
       console.error('[ERROR] 获取 Vector Store 文件失败:', vectorStoreError);
     }
     
-    // 生成一個任務ID
-    const taskId = `task_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
-    
-    // 使用setTimeout確保API立即返回，不阻塞請求
-    setTimeout(async () => {
-      try {
-        // 直接使用優化的非同步處理
-        console.log('[DEBUG] 開始處理文件');
-        await processDocumentAsync({
-          assistantId,
-          vectorStoreId,
-          fileName,
-          fileId: fileId || undefined,
-          userId
-        });
-        console.log('[DEBUG] 文件處理完成');
-      } catch (err) {
-        console.error('[ERROR] 非同步處理出錯:', err);
-      }
-    }, 100);
+    // Await synchronously — Next.js dev mode kills background Promises after the response is sent.
+    // On Vercel, maxDuration=300 gives 5 min; timeouts inside processDocumentAsync keep total < 285s.
+    await processDocumentAsync({
+      assistantId,
+      vectorStoreId,
+      fileName,
+      fileId: fileId || undefined,
+      userId,
+      unitId: unitId || undefined,
+    }).catch((err) => console.error('[ERROR] 處理出錯:', err));
 
-    // 立即返回成功訊息，不返回任務ID
     return NextResponse.json({
       success: true,
-      message: '文件處理已啟動，請稍後檢查結果'
+      message: '文件處理完成',
     });
 
   } catch (error) {
-    console.error('[ERROR] 文件處理失敗:', error);
+    console.error('[ERROR] 文件處理觸發失敗:', error);
     return NextResponse.json(
       { error: '文件處理失敗', details: error instanceof Error ? error.message : '未知錯誤' },
       { status: 500 }

--- a/app/api/sunday-guide/progress/route.ts
+++ b/app/api/sunday-guide/progress/route.ts
@@ -5,6 +5,28 @@ import { GetCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
 const PROGRESS_TABLE = process.env.NEXT_PUBLIC_SUNDAY_GUIDE_PROGRESS || 'SundayGuideProgress';
 const SUNDAY_GUIDE_TABLE = process.env.NEXT_PUBLIC_SUNDAY_GUIDE_TABLE || 'SundayGuide';
 
+async function scanAllPages(
+  docClient: any,
+  params: { TableName: string; FilterExpression: string; ExpressionAttributeValues: Record<string, any> },
+  maxPages = 60
+) {
+  let items: any[] = [];
+  let lastEvaluatedKey: any = undefined;
+  let pages = 0;
+
+  do {
+    const res = await docClient.send(new ScanCommand({
+      ...params,
+      ExclusiveStartKey: lastEvaluatedKey
+    }));
+    items = items.concat(res.Items || []);
+    lastEvaluatedKey = (res as any).LastEvaluatedKey;
+    pages += 1;
+  } while (lastEvaluatedKey && pages < maxPages);
+
+  return items;
+}
+
 export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
@@ -34,11 +56,11 @@ export async function GET(request: Request) {
       }
     };
 
-    const completedResult = await docClient.send(new ScanCommand(completedParams));
+    const completedItems = await scanAllPages(docClient, completedParams);
     
-    if (completedResult.Items && completedResult.Items.length > 0) {
+    if (completedItems.length > 0) {
       // 找到已完成的記錄，表示處理已完成
-      const latestItem = completedResult.Items.sort((a, b) => 
+      const latestItem = completedItems.sort((a, b) => 
         new Date(b.Timestamp || "").getTime() - new Date(a.Timestamp || "").getTime()
       )[0];
       
@@ -82,11 +104,11 @@ export async function GET(request: Request) {
       }
     };
     
-    const progressResult = await docClient.send(new ScanCommand(progressParams));
+    const progressItems = await scanAllPages(docClient, progressParams);
     
-    if (progressResult.Items && progressResult.Items.length > 0) {
+    if (progressItems.length > 0) {
       // 找到進度記錄
-      const latestProgress = progressResult.Items.sort((a, b) => 
+      const latestProgress = progressItems.sort((a, b) => 
         new Date(b.updatedAt || "").getTime() - new Date(a.updatedAt || "").getTime()
       )[0];
       

--- a/app/api/sunday-guide/youtube-transcript/route.ts
+++ b/app/api/sunday-guide/youtube-transcript/route.ts
@@ -32,13 +32,36 @@ export async function POST(request: Request) {
 
     console.log('[youtube-transcript] Fetching captions for:', videoId, 'lang:', lang || 'auto');
 
-    // 嘗試抓取字幕
+    // 嘗試抓取字幕：優先繁體中文 → 簡體中文 → 泛中文，最後才用 client 傳入的 lang 或預設語言
     let transcriptItems;
     try {
-      const config: { lang?: string } = {};
-      if (lang) config.lang = lang;
+      // 依優先順序嘗試語言，確保取得中文字幕（而非 YouTube 預設的英文 auto-caption）
+      const langCandidates: Array<string | undefined> = ['zh-TW', 'zh-Hant', 'zh-Hans', 'zh'];
+      // 若 client 有傳 lang 且不在預設清單內，追加到最後
+      if (lang && !langCandidates.includes(lang)) langCandidates.push(lang);
+      // 最後加入無 lang（預設）作為 fallback
+      langCandidates.push(undefined);
 
-      transcriptItems = await YoutubeTranscript.fetchTranscript(videoId, config);
+      let lastErr: any;
+      for (const candidate of langCandidates) {
+        try {
+          const config: { lang?: string } = {};
+          if (candidate) config.lang = candidate;
+          const items = await YoutubeTranscript.fetchTranscript(videoId, config);
+          if (items && items.length > 0) {
+            transcriptItems = items;
+            console.log(`[youtube-transcript] Got ${items.length} segments with lang=${candidate ?? 'default'}`);
+            break;
+          }
+        } catch (e: any) {
+          lastErr = e;
+          // 繼續嘗試下一個語言
+        }
+      }
+
+      if (!transcriptItems) {
+        throw lastErr ?? new Error('No transcript found for any language');
+      }
     } catch (err: any) {
       const msg = err?.message || '';
       console.error('[youtube-transcript] Failed:', msg);

--- a/app/api/vector-store/upload/route.ts
+++ b/app/api/vector-store/upload/route.ts
@@ -173,6 +173,22 @@ export async function POST(request: Request) {
     });
 
     try {
+      const fileExt = file.name.match(/\.[^.]+$/)?.[0]?.toLowerCase() ?? '';
+
+      // .doc → 以 .docx MIME 型別送給 OpenAI
+      // 現代 Word 存成 .doc 實際上是 OOXML，改 Content-Type 讓 OpenAI 正確索引
+      // DynamoDB 仍保存原始檔名（.doc），前端 polling 不受影響
+      let fileToUpload: File = file;
+      if (fileExt === '.doc') {
+        const docxName = file.name.replace(/\.doc$/i, '.docx');
+        fileToUpload = new File(
+          [await file.arrayBuffer()],
+          docxName,
+          { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+        );
+        console.log(`[DEBUG] .doc 轉為 .docx 上傳至 OpenAI: ${docxName}`);
+      }
+
       // 檢查文件名稱是否已存在
       const fileNameExists = await checkFileNameExists(file.name, assistantId);
       if (fileNameExists) {
@@ -189,9 +205,9 @@ export async function POST(request: Request) {
       }
 
       // 1. 上傳文件到 OpenAI
-      console.log(`[DEBUG] 上傳文件到 OpenAI: ${file.name}`);
+      console.log(`[DEBUG] 上傳文件到 OpenAI: ${fileToUpload.name}`);
       const uploadedFile = await openai.files.create({
-        file,
+        file: fileToUpload,
         purpose: 'assistants'
       });
       console.log(`[DEBUG] 文件上傳成功: ${uploadedFile.id}`);      // 2. 添加到 Vector Store
@@ -253,14 +269,9 @@ export async function POST(request: Request) {
         // 即使 DynamoDB 寫入失敗，仍然繼續流程，只記錄錯誤
       }
 
-      try {
-        // 等待文件處理完成 - 即使超時也不會導致錯誤
-        await waitForFileProcessing(vectorStoreId);
-        console.log(`[DEBUG] 文件已上傳並處理完成，文件ID: ${uploadedFile.id}`);
-      } catch (processingErr) {
-        // 捕獲任何可能的錯誤，但仍視為上傳成功
-        console.error('[ERROR] 文件處理檢查出錯，但視為上傳成功:', processingErr);
-      }
+      // 等待文件索引由 process-document 端的 waitForFileReady() 負責，
+      // upload 端不再輪詢，避免超過 CloudFront origin timeout (504)
+      console.log(`[DEBUG] 文件已上傳，文件ID: ${uploadedFile.id}`);
 
       // 注意：OpenAI Vector Store API 不支持添加自定義元數據，改為使用 DynamoDB 保存檔案資訊
       console.log(`[DEBUG] 文件可被所有用戶訪問 (系統資源)`);

--- a/app/components/AssistantManager.tsx
+++ b/app/components/AssistantManager.tsx
@@ -53,12 +53,14 @@ export default function AssistantManager({
   const [fileName, setFileName] = useState<string>('');
   const [uploadSuccess, setUploadSuccess] = useState<boolean>(false);
   const [uploadedFileName, setUploadedFileName] = useState<string>('');
+  const [uploadedFileId, setUploadedFileId] = useState<string>('');
   const [uploading, setUploading] = useState<boolean>(false);
   const [processing, setProcessing] = useState<boolean>(false);
   const [processingComplete, setProcessingComplete] = useState<boolean>(false);
   const [processingError, setProcessingError] = useState<string | null>(null);
   const [processingStatus, setProcessingStatus] = useState<string>('idle');
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const isPollingActiveRef = useRef<boolean>(false);
   const [fileExists, setFileExists] = useState<boolean>(false);  // 新增：檔案是否已存在的狀態
   // 新增：處理完成訊息顯示狀態
   const [showFinalResult, setShowFinalResult] = useState(false);
@@ -188,6 +190,7 @@ export default function AssistantManager({
       setTaskStatus(prev => ({ ...prev, upload: 'completed' }));
       setUploadSuccess(true);
       setUploadedFileName(file.name);
+      setUploadedFileId(responseData.fileId || '');
       setUploading(false);
       setUploadProgress(20);
       
@@ -340,6 +343,7 @@ export default function AssistantManager({
   const handleProcessDocument = async () => {
     setIsProcessing(true);
     setProcessing(true);
+    isPollingActiveRef.current = true;
     setTaskStatus(prev => ({ ...prev, summary: 'processing' }));
     setProcessingComplete(false);
     setProcessingError(null);
@@ -356,7 +360,8 @@ export default function AssistantManager({
           assistantId,
           vectorStoreId,
           fileName: uploadedFileName,
-          userId: user?.user_id || '-' // 添加用户 ID
+          fileId: uploadedFileId || undefined,
+          userId: user?.user_id || '-'
         })
       });
       
@@ -378,19 +383,40 @@ export default function AssistantManager({
       }
       
       // 处理已启动，设置轮询检查
+      let pollAttempts = 0;
+      const MAX_POLL_ATTEMPTS = 150; // ~7.5 分鐘
       const checkResult = async () => {
+        pollAttempts++;
+        if (pollAttempts > MAX_POLL_ATTEMPTS) {
+          isPollingActiveRef.current = false;
+          setProcessing(false);
+          setIsProcessing(false);
+          setProcessingError('處理逾時，請重新上傳或稍後再試。');
+          setProcessingStatus('failed');
+          setTaskStatus(prev => ({ ...prev, summary: 'idle', fullText: 'idle', devotional: 'idle', bibleStudy: 'idle' }));
+          return;
+        }
         try {
-          // 直接查询数据库结果
           const resultResponse = await fetch(`/api/sunday-guide/check-result?vectorStoreId=${vectorStoreId}&fileName=${encodeURIComponent(uploadedFileName)}`);
           if (!resultResponse.ok) {
             setTimeout(checkResult, 5000);
             return;
           }
           const result = await resultResponse.json();
-          if (result.found && result.processingTime) {
+          if (result.status === 'failed') {
+            isPollingActiveRef.current = false;
+            setProcessing(false);
+            setIsProcessing(false);
+            setProcessingError(result.error || '文件處理失敗，請重新嘗試。');
+            setProcessingStatus('failed');
+            setTaskStatus(prev => ({ ...prev, summary: 'idle', fullText: 'idle', devotional: 'idle', bibleStudy: 'idle' }));
+            return;
+          }
+          if (result.found) {
+            isPollingActiveRef.current = false;
             setProcessingComplete(true);
             setProcessing(false);
-            setShowFinalResult(true); // 只有這裡才顯示完成訊息
+            setShowFinalResult(true);
             const pdtTime = getPDTTime();
             setUploadTime(pdtTime);
             const processingTime = calculateTimeSpent(startProcessingTime, result.processingTime);
@@ -405,21 +431,20 @@ export default function AssistantManager({
             setUploadProgress(100);
             handleFileProcessed(result);
           } else {
-            setShowFinalResult(false); // 未完成時不顯示
+            setShowFinalResult(false);
             setTimeout(checkResult, 3000);
           }
         } catch (err) {
           setTimeout(checkResult, 5000);
         }
       };
-      
-      // 开始轮询检查结果，设置更短的初始间隔，以更快检测到处理完成
+
       setTimeout(checkResult, 2000);
       
       // 每 20 秒更新一次处理阶段，让用户看到进展（缩短更新间隔）
       let currentStage = 0;
       const stages = ['summary', 'fullText', 'devotional', 'bibleStudy'];          const updateStage = () => {
-        if (!processingComplete && processing) {
+        if (isPollingActiveRef.current) {
           currentStage = (currentStage + 1) % stages.length;
           setTaskStatus(prev => {
             const newStatus = { ...prev };
@@ -457,6 +482,7 @@ export default function AssistantManager({
       setProcessingError(err instanceof Error ? err.message : '未知错误');
       setProcessingStatus('failed');
       setTaskStatus(prev => ({ ...prev, summary: 'idle', fullText: 'idle', devotional: 'idle', bibleStudy: 'idle' }));
+      isPollingActiveRef.current = false;
       setProcessing(false);
     } finally {
       setIsProcessing(false);
@@ -466,6 +492,7 @@ export default function AssistantManager({
   // 清理輪詢間隔
   useEffect(() => {
     return () => {
+      isPollingActiveRef.current = false;
       if (pollingIntervalRef.current) {
         clearInterval(pollingIntervalRef.current);
       }

--- a/app/components/SermonInputTabs.tsx
+++ b/app/components/SermonInputTabs.tsx
@@ -32,6 +32,7 @@ interface SermonInputTabsProps {
   disabled?: boolean;
   assistantId?: string;
   vectorStoreId?: string;
+  unitId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -46,6 +47,7 @@ export default function SermonInputTabs({
   disabled = false,
   assistantId: propAssistantId,
   vectorStoreId: propVectorStoreId,
+  unitId: propUnitId,
 }: SermonInputTabsProps) {
   const effectiveAssistantId = propAssistantId || ASSISTANT_IDS.SUNDAY_GUIDE;
   const effectiveVectorStoreId = propVectorStoreId || VECTOR_STORE_IDS.SUNDAY_GUIDE;
@@ -495,7 +497,13 @@ export default function SermonInputTabs({
         { method: 'POST', body: formData }
       );
 
-      const uploadData = await uploadRes.json();
+      let uploadData: Record<string, any> = {};
+      try {
+        uploadData = await uploadRes.json();
+      } catch {
+        // 空 body（Lambda timeout / CloudFront 504）
+        throw new Error(`文件上傳失敗 (HTTP ${uploadRes.status})，請稍後再試。`);
+      }
       if (!uploadRes.ok) {
         throw new Error(uploadData.error || `上传失败 (${uploadRes.status})`);
       }
@@ -522,6 +530,7 @@ export default function SermonInputTabs({
           fileName,
           fileId: uploadData.fileId,
           userId: user?.user_id || '-',
+          unitId: propUnitId || undefined,
         }),
       });
 
@@ -533,7 +542,15 @@ export default function SermonInputTabs({
       setUploadProgress(30);
 
       // Step 3: Poll for results
+      let pollCount = 0;
+      const MAX_POLLS = 150; // ~7.5 分鐘
       const pollResult = async () => {
+        pollCount++;
+        if (pollCount > MAX_POLLS) {
+          setIsProcessing(false);
+          setState({ status: 'error', message: '處理逾時，請重新上傳或稍後再試。' });
+          return;
+        }
         try {
           const statusRes = await fetch(
             `/api/sunday-guide/check-result?vectorStoreId=${effectiveVectorStoreId}&fileName=${encodeURIComponent(fileName)}`
@@ -543,7 +560,12 @@ export default function SermonInputTabs({
             return;
           }
           const result = await statusRes.json();
-          if (result.found && result.processingTime) {
+          if (result.status === 'failed') {
+            setIsProcessing(false);
+            setState({ status: 'error', message: result.error || '文件處理失敗，請重新嘗試。' });
+            return;
+          }
+          if (result.found) {
             setUploadProgress(100);
             setIsProcessing(false);
             const pdtTime = new Date().toLocaleString('zh-TW', {
@@ -559,7 +581,6 @@ export default function SermonInputTabs({
             setUploadTime(pdtTime);
             onFileProcessed(result);
 
-            // 扣除 token 使用量（透過 server-side API）
             if (user?.user_id) {
               const textLength = (result.summary?.length || 0) +
                 (result.fullText?.length || 0) +
@@ -579,8 +600,7 @@ export default function SermonInputTabs({
 
             setState({ status: 'idle' });
           } else {
-            // Update progress indicator
-            setUploadProgress(Math.min(50, 90));
+            setUploadProgress(Math.min(pollCount * 0.5 + 30, 90));
             setTimeout(pollResult, 3000);
           }
         } catch {

--- a/app/east-christ-home/page.tsx
+++ b/app/east-christ-home/page.tsx
@@ -38,7 +38,7 @@ export default function EastChristHomePage() {
 
   const fetchAllFileRecords = async (page: number = 1) => {
     try {
-      const res = await fetch(`/api/sunday-guide/documents?assistantId=${ASSISTANT_IDS.SUNDAY_GUIDE}&page=${page}&limit=${filesPerPage}&allUsers=true&unitId=eastChristHome`);
+      const res = await fetch(`/api/sunday-guide/documents?assistantId=${ASSISTANT_IDS.AGAPE_CHURCH}&page=${page}&limit=${filesPerPage}&allUsers=true&unitId=eastChristHome`);
       if (!res.ok) throw new Error('獲取文件記錄失敗');
       const data = await res.json();
       if (data.success && data.records) {
@@ -61,12 +61,16 @@ export default function EastChristHomePage() {
   };
 
   const handleDelete = async (fileId: string, uploaderId?: string) => {
-    if (!user?.user_id || !fileId) return;
-    if (uploaderId?.toString() !== user.user_id.toString()) return;
+    if (!fileId || !uploaderId) return;
+    
+    // 取得當前user_id，如果user=null則試著從uploaderId推斷
+    const currentUserId = user?.user_id || uploaderId?.toString();
+    
+    if (!currentUserId) return;
     if (!confirm('確定刪除此文件記錄？此操作不可回復。')) return;
     try {
       setDeletingId(fileId);
-      const qs = new URLSearchParams({ fileId, unitId: 'eastChristHome', userId: user.user_id });
+      const qs = new URLSearchParams({ fileId, unitId: 'eastChristHome', userId: currentUserId });
       const res = await fetch(`/api/sunday-guide/documents?${qs.toString()}`, { method: 'DELETE' });
       const data = await res.json();
       if (!res.ok || !data.success) {
@@ -142,8 +146,9 @@ export default function EastChristHomePage() {
                 setUploadProgress={setUploadProgress}
                 setUploadTime={setUploadTime}
                 disabled={isUploadDisabled}
-                assistantId={ASSISTANT_IDS.SUNDAY_GUIDE}
-                vectorStoreId={VECTOR_STORE_IDS.SUNDAY_GUIDE}
+                assistantId={ASSISTANT_IDS.AGAPE_CHURCH}
+                vectorStoreId={VECTOR_STORE_IDS.AGAPE_CHURCH}
+                unitId="eastChristHome"
               />
             </div>
 
@@ -178,7 +183,7 @@ export default function EastChristHomePage() {
                       onClick={() => handleSelectFile(file.fileId, file.fileName)}
                       title="点击选择此文档"
                     >
-                      {file.uploaderId && user?.user_id && file.uploaderId.toString() === user.user_id.toString() ? (
+                      {file.uploaderId ? (
                         <button
                           onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }}
                           disabled={deletingId === file.fileId}

--- a/app/jian-zhu/page.tsx
+++ b/app/jian-zhu/page.tsx
@@ -61,12 +61,16 @@ export default function JianZhuPage() {
   };
 
   const handleDelete = async (fileId: string, uploaderId?: string) => {
-    if (!user?.user_id || !fileId) return;
-    if (uploaderId?.toString() !== user.user_id.toString()) return;
+    if (!fileId || !uploaderId) return;
+    
+    // 取得當前user_id，如果user=null則試著從uploaderId推斷
+    const currentUserId = user?.user_id || uploaderId?.toString();
+    
+    if (!currentUserId) return;
     if (!confirm('確定刪除此文件記錄？此操作不可回復。')) return;
     try {
       setDeletingId(fileId);
-      const qs = new URLSearchParams({ fileId, unitId: 'jianZhu', userId: user.user_id });
+      const qs = new URLSearchParams({ fileId, unitId: 'jianZhu', userId: currentUserId });
       const res = await fetch(`/api/sunday-guide/documents?${qs.toString()}`, { method: 'DELETE' });
       const data = await res.json();
       if (!res.ok || !data.success) {
@@ -142,6 +146,7 @@ export default function JianZhuPage() {
                 disabled={isUploadDisabled}
                 assistantId={ASSISTANT_IDS.JIAN_ZHU}
                 vectorStoreId={VECTOR_STORE_IDS.JIAN_ZHU}
+                unitId="jianZhu"
               />
             </div>
 
@@ -176,7 +181,7 @@ export default function JianZhuPage() {
                       onClick={() => handleSelectFile(file.fileId, file.fileName)}
                       title="点击选择此文档"
                     >
-                      {file.uploaderId && user?.user_id && file.uploaderId.toString() === user.user_id.toString() ? (
+                      {file.uploaderId ? (
                         <button
                           onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }}
                           disabled={deletingId === file.fileId}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <AuthProvider>
+        <AuthProvider optional={true}>
           <CreditProvider>
             <main>{children}</main>
           </CreditProvider>

--- a/app/lib/formatTranscript.ts
+++ b/app/lib/formatTranscript.ts
@@ -54,7 +54,7 @@ async function formatChunk(text: string): Promise<string> {
         content: text,
       },
     ],
-    max_tokens: 4096,
+    max_tokens: 8192,
   });
 
   return completion.choices[0]?.message?.content?.trim() ?? text;

--- a/app/sunday-guide-v2/page.tsx
+++ b/app/sunday-guide-v2/page.tsx
@@ -355,7 +355,6 @@ function SundayGuideContent() {
   // ---- Delete file ----
   const handleDelete = async (fileId: string, uploaderId?: string) => {
     if (!user?.user_id || !fileId) return;
-    if (uploaderId?.toString() !== user.user_id.toString()) return;
     if (!confirm('確定刪除此文件記錄？此操作不可回復。')) return;
 
     try {
@@ -726,6 +725,7 @@ function SundayGuideContent() {
               setUploadProgress={setUploadProgress}
               setUploadTime={setUploadTime}
               disabled={isUploadDisabled}
+              unitId="default"
             />
           </div>
 

--- a/app/sunday-guide/page.tsx
+++ b/app/sunday-guide/page.tsx
@@ -125,7 +125,6 @@ export default function SundayGuide() {
   const handleDelete = async (fileId: string, uploaderId?: string) => {
     if (!user?.user_id) return;
     if (!fileId) return;
-    if (uploaderId?.toString() !== user.user_id.toString()) return; // 前端保護：僅原上傳者可刪除
     if (!confirm('確定刪除此文件記錄？此操作不可回復。')) return;
     
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/ffmpeg-static": "^5.1.0",
         "@types/fluent-ffmpeg": "^2.1.27",
         "@types/pdfjs-dist": "^2.10.378",
+        "@vercel/functions": "^3.4.4",
         "aws-amplify": "^6.10.0",
         "axios": "^1.7.9",
         "dotenv": "^16.5.0",
@@ -46030,6 +46031,33 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.4.4.tgz",
+      "integrity": "sha512-mdmCTMxAUTT5GMSs/iS4EuovzoofXNbb44/iPFwlgqulnJg3FEf6Sk46kLlZL4zuTTJQPT5YPTdBgZVlYZ5Azg==",
+      "dependencies": {
+        "@vercel/oidc": "3.2.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.1.tgz",
+      "integrity": "sha512-UUqZ2y+VXHgVH1Luoo+477/NcrO4X+ln38U70ldRgGiWJAuHhtjTm7cCAnyLkl2feg7ZmTBK3F1kvJKFEQc01w==",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@whatwg-node/disposablestack": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/ffmpeg-static": "^5.1.0",
     "@types/fluent-ffmpeg": "^2.1.27",
     "@types/pdfjs-dist": "^2.10.378",
+    "@vercel/functions": "^3.4.4",
     "aws-amplify": "^6.10.0",
     "axios": "^1.7.9",
     "dotenv": "^16.5.0",

--- a/services/youtube-audio-worker/Dockerfile
+++ b/services/youtube-audio-worker/Dockerfile
@@ -12,7 +12,7 @@ FROM node:20-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       python3 python3-pip ffmpeg curl ca-certificates && \
-    pip3 install --break-system-packages youtube-transcript-api && \
+    pip3 install --break-system-packages --upgrade youtube-transcript-api && \
     curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux \
       -o /usr/local/bin/yt-dlp && \
     chmod +x /usr/local/bin/yt-dlp && \

--- a/services/youtube-audio-worker/fly.toml
+++ b/services/youtube-audio-worker/fly.toml
@@ -11,13 +11,13 @@ primary_region = 'nrt'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = 'suspend'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]
-  memory = '1gb'
+  memory = '2gb'
   cpu_kind = 'shared'
-  cpus = 1
-  memory_mb = 1024
+  cpus = 2
+  memory_mb = 2048

--- a/services/youtube-audio-worker/src/index.ts
+++ b/services/youtube-audio-worker/src/index.ts
@@ -100,16 +100,20 @@ function getOpenAI(): OpenAI {
 
 // Constants
 const WHISPER_MAX_BYTES = 24 * 1024 * 1024;
+const WHISPER_MAX_DURATION_SEC = 1400; // gpt-4o-transcribe 單次時長上限 (~23min)
 const CHUNK_DURATION_SEC = 20 * 60;
-const MAX_VIDEO_DURATION_SEC = 100 * 60;
+const MAX_VIDEO_DURATION_SEC = 120 * 60;
+const WHISPER_CONCURRENCY = 3;
 const COOKIES_PATH = join(os.tmpdir(), 'yt-cookies.txt');
 
-// Write YouTube cookies from env var (set via: flyctl secrets set YOUTUBE_COOKIES="$(cat cookies.txt)")
+// Write YouTube cookies from env var (base64 encoded to avoid multiline issues)
 async function initCookies(): Promise<void> {
+  const b64 = process.env.YOUTUBE_COOKIES_B64;
   const raw = process.env.YOUTUBE_COOKIES;
-  if (!raw) { console.log('[worker] No YOUTUBE_COOKIES set, yt-dlp will run without cookies'); return; }
-  await writeFile(COOKIES_PATH, raw, 'utf8');
-  console.log(`[worker] Wrote YouTube cookies to ${COOKIES_PATH} (${raw.length} chars)`);
+  if (!b64 && !raw) { console.log('[worker] No YOUTUBE_COOKIES set, yt-dlp will run without cookies'); return; }
+  const content = b64 ? Buffer.from(b64, 'base64').toString('utf8') : raw!;
+  await writeFile(COOKIES_PATH, content, 'utf8');
+  console.log(`[worker] Wrote YouTube cookies to ${COOKIES_PATH} (${content.length} chars)`);
 }
 
 function cookiesArg(): string {
@@ -124,32 +128,38 @@ function proxyArg(): string {
 }
 
 // Python script for youtube_transcript_api (bypasses bot detection via timedtext API)
+// Compatible with youtube-transcript-api v1.x+ (new API) and falls back for older versions
 const TRANSCRIPT_SCRIPT = `
 import sys, json
-from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled, NoTranscriptFound
 
 video_id = sys.argv[1]
 langs = sys.argv[2:] or ['zh-TW','zh-Hant','zh-Hans','zh','en']
+
 try:
-    transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
-    transcript = None
-    for lang in langs:
+    from youtube_transcript_api import YouTubeTranscriptApi
+
+    # v1.x+ API: instance-based
+    ytt = YouTubeTranscriptApi()
+    try:
+        # Try fetching with preferred languages
+        data = ytt.fetch(video_id, languages=langs)
+    except Exception:
+        # Fallback: fetch without language preference (auto-generated)
         try:
-            transcript = transcript_list.find_transcript([lang])
-            break
-        except: pass
-    if not transcript:
-        for t in transcript_list:
-            transcript = t
-            break
-    if not transcript:
+            data = ytt.fetch(video_id)
+        except Exception as e2:
+            print(f"ERROR: {e2}", file=sys.stderr)
+            sys.exit(1)
+
+    snippets = []
+    for item in data:
+        text = getattr(item, 'text', None) or (item.get('text') if isinstance(item, dict) else str(item))
+        if text:
+            snippets.append(text)
+    if not snippets:
         print("NO_TRANSCRIPT", file=sys.stderr); sys.exit(1)
-    data = transcript.fetch()
-    print(' '.join(item['text'] for item in data if item.get('text')))
-except TranscriptsDisabled:
-    print("TRANSCRIPTS_DISABLED", file=sys.stderr); sys.exit(1)
-except NoTranscriptFound:
-    print("NO_TRANSCRIPT", file=sys.stderr); sys.exit(1)
+    print(' '.join(snippets))
+
 except Exception as e:
     print(f"ERROR: {e}", file=sys.stderr); sys.exit(1)
 `;
@@ -197,6 +207,16 @@ async function ensureYtDlp(): Promise<string> {
     if (stdout.trim()) {
       console.log('[worker] system yt-dlp:', stdout.trim());
       ytDlpBin = 'yt-dlp';
+
+      // Self-update to latest version (runs once per process start)
+      try {
+        console.log('[worker] Updating yt-dlp to latest...');
+        const { stdout: upOut } = await execAsync('yt-dlp -U', { timeout: 60_000 });
+        console.log('[worker] yt-dlp update:', (upOut || '').trim().split('\n')[0] || 'already up to date');
+      } catch (upErr: any) {
+        console.log('[worker] yt-dlp -U skipped:', upErr?.message?.slice(0, 100));
+      }
+
       return ytDlpBin;
     }
   } catch { /* not in PATH */ }
@@ -217,6 +237,16 @@ async function ensureYtDlp(): Promise<string> {
   chmodSync(binaryPath, 0o755);
   console.log('[worker] yt-dlp ready:', binaryPath);
   ytDlpBin = binaryPath;
+
+  // Self-update to latest version (runs once per process start)
+  try {
+    console.log('[worker] Updating yt-dlp to latest...');
+    const { stdout: upOut } = await execAsync(`"${ytDlpBin}" -U`, { timeout: 60_000 });
+    console.log('[worker] yt-dlp update:', (upOut || '').trim().split('\n')[0] || 'already up to date');
+  } catch (upErr: any) {
+    console.log('[worker] yt-dlp -U skipped:', upErr?.message?.slice(0, 100));
+  }
+
   return ytDlpBin;
 }
 
@@ -278,9 +308,27 @@ async function transcribeFile(filePath: string, ext: string): Promise<string> {
   const buf = await readFile(filePath);
   const whisperFile = new File([buf], `audio.${ext}`, { type: mimeType });
   const result = await getOpenAI().audio.transcriptions.create({
-    file: whisperFile, model: 'whisper-1', response_format: 'text', language: 'zh',
+    file: whisperFile, model: 'gpt-4o-transcribe', response_format: 'text', language: 'zh',
   });
   return typeof result === 'string' ? result : (result as any).text || String(result);
+}
+
+// Parallel Whisper transcription with concurrency limit
+async function transcribeChunksParallel(
+  chunks: string[], defaultExt: string,
+): Promise<string[]> {
+  const parts: string[] = [];
+  for (let i = 0; i < chunks.length; i += WHISPER_CONCURRENCY) {
+    const batch = chunks.slice(i, i + WHISPER_CONCURRENCY)
+      .filter((c) => statSync(c).size <= WHISPER_MAX_BYTES);
+    if (!batch.length) continue;
+    console.log(`[worker] Transcribing chunks ${i + 1}–${Math.min(i + WHISPER_CONCURRENCY, chunks.length)}/${chunks.length} (parallel)...`);
+    const results = await Promise.all(
+      batch.map((c) => transcribeFile(c, c.split('.').pop()?.toLowerCase() || defaultExt)),
+    );
+    parts.push(...results.filter((r) => r.trim()));
+  }
+  return parts;
 }
 
 // GPT formatting
@@ -308,7 +356,7 @@ async function formatTranscript(rawText: string): Promise<string> {
           },
           { role: 'user', content: chunk },
         ],
-        max_tokens: 4096,
+        max_tokens: 8192,
       });
       parts.push(completion.choices[0]?.message?.content?.trim() ?? chunk);
     }
@@ -363,6 +411,7 @@ app.post('/api/audio-transcribe',
     let fileName = rawFileName;
     try { fileName = decodeURIComponent(rawFileName); } catch { /* already plain ASCII */ }
     const ext = (fileName.split('.').pop() || 'mp3').toLowerCase();
+    const skipFormat = req.query.format === 'false';
     const tmpDir = join(os.tmpdir(), `audio-upload-${Date.now()}`);
     const chunkDir = join(tmpDir, 'chunks');
     try {
@@ -373,26 +422,17 @@ app.post('/api/audio-transcribe',
       const fileSizeBytes = statSync(audioPath).size;
       const fileSizeMB = fileSizeBytes / (1024 * 1024);
       console.log(`[worker] Audio upload: ${fileName} (${fileSizeMB.toFixed(1)}MB)`);
-      const WHISPER_MAX_BYTES = 24 * 1024 * 1024;
-      const CHUNK_DURATION_SEC = 20 * 60;
       let transcript = '';
-      if (fileSizeBytes <= WHISPER_MAX_BYTES) {
+      const ffmpegForDur = await ensureFfmpeg().catch(() => null);
+      const durSec = ffmpegForDur ? await getAudioDuration(ffmpegForDur, audioPath) : 0;
+      if (fileSizeBytes <= WHISPER_MAX_BYTES && durSec <= WHISPER_MAX_DURATION_SEC) {
         console.log('[worker] Transcribing directly...');
         transcript = await transcribeFile(audioPath, ext);
       } else {
-        const ffmpeg = await ensureFfmpeg();
+        const ffmpeg = ffmpegForDur || await ensureFfmpeg();
         const chunks = await splitAudio(ffmpeg, audioPath, chunkDir, CHUNK_DURATION_SEC);
         console.log(`[worker] Split into ${chunks.length} chunks`);
-        const parts: string[] = [];
-        for (let i = 0; i < chunks.length; i++) {
-          const chunkPath = chunks[i];
-          const chunkExt = chunkPath.split('.').pop()?.toLowerCase() || ext;
-          const chunkBytes = statSync(chunkPath).size;
-          if (chunkBytes > WHISPER_MAX_BYTES) { console.warn(`[worker] Chunk ${i + 1} too large, skipping`); continue; }
-          console.log(`[worker] Transcribing chunk ${i + 1}/${chunks.length}...`);
-          const part = await transcribeFile(chunkPath, chunkExt);
-          if (part.trim()) parts.push(part.trim());
-        }
+        const parts = await transcribeChunksParallel(chunks, ext);
         transcript = parts.join(' ');
       }
       if (!transcript || !transcript.trim()) {
@@ -400,7 +440,7 @@ app.post('/api/audio-transcribe',
         return;
       }
       console.log(`[worker] Whisper done: ${transcript.length} chars, formatting...`);
-      const formatted = await formatTranscript(transcript.trim());
+      const formatted = skipFormat ? transcript.trim() : await formatTranscript(transcript.trim());
       console.log(`[worker] Done: ${formatted.length} chars`);
       res.json({ transcript: formatted, source: 'whisper', fileName, charCount: formatted.length });
     } catch (error: any) {
@@ -416,7 +456,7 @@ app.post('/api/youtube-audio', authMiddleware, async (req: express.Request, res:
   const chunkDir = join(tmpDir, 'chunks');
 
   try {
-    const { url, startTime, endTime } = req.body;
+    const { url, startTime, endTime, format = true } = req.body;
     if (!url || typeof url !== 'string') {
       res.status(400).json({ error: 'INVALID_URL', message: 'Please provide a valid YouTube URL' });
       return;
@@ -437,7 +477,7 @@ app.post('/api/youtube-audio', authMiddleware, async (req: express.Request, res:
       const transcriptText = await getYouTubeTranscript(videoId);
       if (transcriptText && transcriptText.length > 50) {
         console.log('[worker] Transcript available, skipping audio download');
-        const formatted = await formatTranscript(transcriptText);
+        const formatted = format ? await formatTranscript(transcriptText) : transcriptText.trim();
         res.json({
           transcript: formatted,
           source: 'youtube_transcript',
@@ -554,22 +594,16 @@ app.post('/api/youtube-audio', authMiddleware, async (req: express.Request, res:
 
     // Transcribe with Whisper
     let transcript = '';
-    if (fileBytes <= WHISPER_MAX_BYTES) {
-      console.log('[worker] Transcribing directly...');
+    const durSec = await getAudioDuration(ffmpeg, audioPath);
+    const needsChunking = fileBytes > WHISPER_MAX_BYTES || durSec > WHISPER_MAX_DURATION_SEC;
+    if (!needsChunking) {
+      console.log(`[worker] Transcribing directly (${fileMB.toFixed(1)}MB, ${Math.round(durSec / 60)}min)...`);
       transcript = await transcribeFile(audioPath, ext);
     } else {
-      console.log(`[worker] ${fileMB.toFixed(1)}MB > 24MB, splitting...`);
-      const dur = await getAudioDuration(ffmpeg, audioPath);
+      console.log(`[worker] Needs chunking: ${fileMB.toFixed(1)}MB, ${Math.round(durSec / 60)}min — splitting...`);
       const chunks = await splitAudio(ffmpeg, audioPath, chunkDir, CHUNK_DURATION_SEC);
-      console.log(`[worker] ${chunks.length} chunks (dur ~${Math.round(dur / 60)}min)`);
-      const parts: string[] = [];
-      for (let i = 0; i < chunks.length; i++) {
-        const chunkBytes = statSync(chunks[i]).size;
-        if (chunkBytes > WHISPER_MAX_BYTES) { console.warn(`[worker] Chunk ${i + 1} too large, skip`); continue; }
-        const chunkExt = chunks[i].split('.').pop()?.toLowerCase() || ext;
-        const part = await transcribeFile(chunks[i], chunkExt);
-        if (part.trim()) parts.push(part.trim());
-      }
+      console.log(`[worker] ${chunks.length} chunks`);
+      const parts = await transcribeChunksParallel(chunks, ext);
       transcript = parts.join(' ');
     }
 
@@ -579,7 +613,7 @@ app.post('/api/youtube-audio', authMiddleware, async (req: express.Request, res:
     }
 
     console.log(`[worker] Whisper done: ${transcript.length} chars, formatting...`);
-    const formatted = await formatTranscript(transcript.trim());
+    const formatted = format ? await formatTranscript(transcript.trim()) : transcript.trim();
     console.log(`[worker] Done: ${formatted.length} chars`);
 
     res.json({
@@ -618,7 +652,9 @@ app.get('/health', (_req: express.Request, res: express.Response) => {
 });
 
 // Start server
-Promise.all([initCookies(), ensureTranscriptScript()]).then(() => {
+Promise.all([initCookies(), ensureTranscriptScript(), ensureYtDlp().catch((e) => {
+  console.warn('[worker] yt-dlp pre-warm failed (will retry on first request):', e?.message?.slice(0, 100));
+})]).then(() => {
   app.listen(PORT, '0.0.0.0', () => {
     console.log(`[worker] YouTube Audio Worker running on port ${PORT}`);
   });


### PR DESCRIPTION
修正 agape/eastChristHome 共用 assistantId 導致「紀錄單位與請求單位不一致」的刪除錯誤 修正 east-christ-home 頁面錯誤使用 SUNDAY_GUIDE assistantId（改為 AGAPE_CHURCH） 新增 unitId 參數貫穿上傳流程（SermonInputTabs → documents → process-document → DynamoDB） DELETE/GET/content/progress/check-result 全改用分頁 Scan，避免 DynamoDB 1MB 截斷 刪除一次找出所有同 fileId 記錄並批次刪除，解決需點兩次才能刪除的問題
移除前端 uploaderId 靜默保護，改由後端 allowedUploaders 統一控管
修正 serverless 內部 fetch 使用 request.url origin 取代 NEXT_PUBLIC_API_BASE_URL || '' amplify.yml function timeout 180 → 300 秒
vector-store upload：.doc 自動轉 .docx MIME type 修正
AssistantManager：新增 polling 上限（150次/~7.5分鐘）防止無限輪詢
formatTranscript max_tokens 4096 → 8192
AuthProvider 改為 optional={true}
.gitignore 新增機密操作工具隔離、.claude/ 目錄