### PR TITLE
fix: add --legacy-peer-deps to both Amplify build phases

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,7 +3,7 @@ backend:
   phases:
     build:
       commands:
-        - npm ci --cache .npm --prefer-offline
+        - npm ci --cache .npm --prefer-offline --legacy-peer-deps
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
   function:
     timeout: 300  # 增加超時時間至 5 分鐘 (300 秒)，與 process-document maxDuration 一致


### PR DESCRIPTION
@aws-amplify/backend-output-schemas requires zod@^3.22.2 but the project now uses zod v4. Added --legacy-peer-deps to both the backend (npm ci --cache .npm --prefer-offline) and frontend (npm ci) install commands in amplify.yml to bypass the peer dependency conflict during Amplify deployment.