### PR TITLE
feat: integrate navigator panel into church pages & update chat send …

### DIFF
--- a/app/agape-church/page.tsx
+++ b/app/agape-church/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import SermonInputTabs from '../components/SermonInputTabs';
 import WithChat from '../components/layouts/WithChat';
 import UserIdDisplay from '../components/UserIdDisplay';
 import { useCredit } from '../contexts/CreditContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useChat } from '../contexts/ChatContext';
+import ConversationList from '../components/ConversationList';
+import MessageList from '../components/Chat/MessageList';
+import ChatInput from '../components/Chat/ChatInput';
+import ReactMarkdown from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
+import chatStyles from './navigator/chat.module.css';
 import { ASSISTANT_IDS, VECTOR_STORE_IDS } from '../config/constants';
 
 interface ProcessedContent {
@@ -16,7 +22,12 @@ interface ProcessedContent {
   bibleStudy: string;
 }
 
-export default function AgapeChurchPage() {
+type GuideMode = 'summary' | 'devotional' | 'bible' | null;
+
+// ─────────────────────────────────────────────────────────────────
+// Inner component — runs inside WithChat's ChatProvider
+// ─────────────────────────────────────────────────────────────────
+function AgapeChurchContent() {
   const { refreshUsage, hasInsufficientTokens, remainingCredits } = useCredit();
   const { user } = useAuth();
   const [isProcessing, setIsProcessing] = useState(false);
@@ -37,6 +48,31 @@ export default function AgapeChurchPage() {
   const [allowedUploaders, setAllowedUploaders] = useState<string[]>([]);
   const hasUploadPermission = !!user?.user_id && allowedUploaders.includes(user.user_id);
 
+  // ── Navigator states ─────────────────────────────────────────
+  const [selectedMode, setSelectedMode] = useState<GuideMode>(null);
+  const [sermonContent, setSermonContent] = useState<string | null>(null);
+  const [navLoading, setNavLoading] = useState(false);
+  const [navFileName, setNavFileName] = useState<string>('');
+  const [navUploadTime, setNavUploadTime] = useState<string>('');
+  const [pdfLoading, setPdfLoading] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // ── Chat context (provided by WithChat) ──────────────────────
+  const {
+    messages,
+    currentThreadId,
+    setCurrentThreadId,
+    sendMessage,
+    isLoading: chatLoading,
+    error: chatError,
+    setError: setChatError,
+    setMessages,
+    loadChatHistory,
+  } = useChat();
+  const shouldLoadHistory = useRef(false);
+
   useEffect(() => {
     fetch('/api/admin/sunday-guide-units')
       .then((r) => r.json())
@@ -47,6 +83,35 @@ export default function AgapeChurchPage() {
   }, []);
 
   useEffect(() => { setIsUploadDisabled(remainingCredits <= 0); }, [remainingCredits, hasInsufficientTokens]);
+
+  // ── Chat error auto-clear ─────────────────────────────────────
+  useEffect(() => {
+    if (chatError) {
+      const t = setTimeout(() => setChatError(''), 8000);
+      return () => clearTimeout(t);
+    }
+  }, [chatError, setChatError]);
+
+  useEffect(() => {
+    if (currentThreadId && user && shouldLoadHistory.current) {
+      shouldLoadHistory.current = false;
+      loadChatHistory(user.user_id);
+    }
+  }, [currentThreadId]);
+
+  // Restore selected file from localStorage once files load
+  useEffect(() => {
+    if (allFiles.length === 0) return;
+    const storedId = typeof window !== 'undefined' ? localStorage.getItem('selectedFileId') : null;
+    const storedName = typeof window !== 'undefined' ? localStorage.getItem('selectedFileName') : null;
+    const target = (storedId ? allFiles.find(f => f.fileId === storedId) : null) || allFiles[0];
+    if (!target) return;
+    if (!selectedFileId) setSelectedFileId(target.fileId);
+    const displayName = (!target.fileName.toLowerCase().endsWith('.pdf') && target.sermonTitle)
+      ? target.sermonTitle : target.fileName;
+    setNavFileName(storedName || displayName);
+    setNavUploadTime(target.uploadDate);
+  }, [allFiles]);
 
   const fetchAllFileRecords = async () => {
     try {
@@ -88,7 +153,13 @@ export default function AgapeChurchPage() {
         alert('刪除失敗: ' + (data.error || res.status));
       } else {
         await fetchAllFileRecords();
-        if (selectedFileId === fileId) setSelectedFileId(null);
+        if (selectedFileId === fileId) {
+          setSelectedFileId(null);
+          setNavFileName('');
+          setNavUploadTime('');
+          setSermonContent(null);
+          setSelectedMode(null);
+        }
       }
     } catch (e: any) {
       alert('刪除時發生錯誤: ' + (e.message || '未知錯誤'));
@@ -111,6 +182,7 @@ export default function AgapeChurchPage() {
       const data = await res.json();
       if (res.ok && data.success) {
         setAllFiles(prev => prev.map(f => f.fileId === fileId ? { ...f, sermonTitle: data.sermonTitle } : f));
+        if (selectedFileId === fileId) setNavFileName(data.sermonTitle || newTitle.trim());
       } else {
         alert('更新失敗: ' + (data.error || res.status));
       }
@@ -132,8 +204,16 @@ export default function AgapeChurchPage() {
 
   const handleSelectFile = (fileId: string) => {
     setSelectedFileId(fileId);
+    // Reset navigator content when a new file is chosen
+    setSermonContent(null);
+    setSelectedMode(null);
+    const file = recentFiles.find(f => f.fileId === fileId);
+    const displayName = file
+      ? ((!file.fileName.toLowerCase().endsWith('.pdf') && file.sermonTitle) ? file.sermonTitle : file.fileName)
+      : '';
+    setNavFileName(displayName);
+    setNavUploadTime(file?.uploadDate || '');
     try {
-      const file = recentFiles.find(f => f.fileId === fileId);
       localStorage.setItem('selectedFileId', fileId);
       if (file) localStorage.setItem('selectedFileName', file.fileName);
       const channel = new BroadcastChannel('file-selection');
@@ -150,10 +230,100 @@ export default function AgapeChurchPage() {
     }
   };
 
+  // ── Navigator functions ──────────────────────────────────────
+  const handleCreateNewThread = () => {
+    setCurrentThreadId(null);
+    setMessages([]);
+  };
+
+  const handleSelectThread = (threadId: string) => {
+    if (threadId === currentThreadId) return;
+    shouldLoadHistory.current = true;
+    setChatError('');
+    setMessages([]);
+    setCurrentThreadId(threadId);
+    setSidebarOpen(false);
+  };
+
+  const handleSendMessage = async (message: string) => {
+    await sendMessage(message);
+    window.dispatchEvent(new CustomEvent('refreshConversations'));
+  };
+
+  const handleModeSelect = async (mode: GuideMode) => {
+    if (!selectedFileId) return;
+    setSelectedMode(mode);
+    setNavLoading(true);
+    try {
+      const userId = user?.user_id || '';
+      const apiUrl = `/api/sunday-guide/content/${ASSISTANT_IDS.AGAPE_CHURCH}?type=${mode}&userId=${encodeURIComponent(userId)}&fileId=${encodeURIComponent(selectedFileId)}`;
+      const response = await fetch(apiUrl);
+      if (response.status === 202) {
+        const data = await response.json().catch(() => ({}));
+        setSelectedMode(null);
+        alert(data.error || '內容正在生成中，請稍候再試');
+        return;
+      }
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({ error: '未知錯誤' }));
+        throw new Error(`获取内容失败: ${response.status} - ${errData.error || response.statusText}`);
+      }
+      const data = await response.json();
+      setSermonContent(data.content);
+      await refreshUsage();
+    } catch (e) {
+      console.error(e);
+      alert(e instanceof Error ? e.message : '請稍後重試');
+    } finally {
+      setNavLoading(false);
+    }
+  };
+
+  const handleDownloadPDF = () => {
+    setPdfError(null);
+    setPdfLoading(true);
+    try {
+      const userId = user?.user_id || '';
+      const params = new URLSearchParams();
+      params.set('assistantId', ASSISTANT_IDS.AGAPE_CHURCH);
+      params.set('userId', userId);
+      params.set('includeAll', 'true');
+      window.open(`/api/sunday-guide/download-pdf?${params.toString()}`, '_blank');
+      setTimeout(() => setPdfLoading(false), 1200);
+    } catch (err) {
+      console.error('PDF 下載失敗', err);
+      setPdfError(err instanceof Error ? err.message : '下載失敗');
+      setPdfLoading(false);
+    }
+  };
+
+  const renderNavContent = () => {
+    if (navLoading) return <div className={styles.loading}>加载中，请稍候...</div>;
+    if (!sermonContent) return null;
+    const titles: Record<string, string> = { summary: '讲道总结', devotional: '每日灵修', bible: '查经指引' };
+    return (
+      <div className={styles.contentBox}>
+        <div className={styles.contentHeader}>
+          <h2>{titles[selectedMode!]}</h2>
+          <button
+            className={styles.downloadButton}
+            onClick={handleDownloadPDF}
+            disabled={pdfLoading}
+          >
+            {pdfLoading ? '生成中...' : '下载完整版'}
+          </button>
+        </div>
+        {pdfError && <div className={styles.errorMessage}>{pdfError}</div>}
+        <div className={styles.markdownContent} ref={contentRef}>
+          <ReactMarkdown>{sermonContent}</ReactMarkdown>
+        </div>
+      </div>
+    );
+  };
+
   return (
-    <WithChat chatType="sunday-guide">
-      <div className={styles.container}>
-        <UserIdDisplay />
+    <div className={styles.container}>
+      <UserIdDisplay />
 
         {/* =============== 1. Upload Section =============== */}
         {hasUploadPermission && (
@@ -289,16 +459,100 @@ export default function AgapeChurchPage() {
             )}
           </aside>
 
-          <div className={styles.guidePlaceholder}>
-            <div className={styles.guidePlaceholderIcon}>👈</div>
-            <p className={styles.guidePlaceholderText}>
-              选择讲章后可前往<br />
-              <a href="/agape-church/navigator" style={{ color: '#0070f3', textDecoration: 'underline' }}>愛加倍信息導覽</a><br />
-              查看信息总结、灵修与查经
-            </p>
+          {/* ── Right: Navigator Panel (hidden on mobile ≤900px) ── */}
+          <div className={styles.navigatorPanel}>
+            <h2 style={{ textAlign: 'center', fontSize: '1.1rem', fontWeight: 700, color: '#1e293b', margin: '0 0 0.5rem' }}>
+              主日信息导航
+            </h2>
+
+            {navFileName && (
+              <div style={{ fontSize: '13px', color: '#0070f3', marginBottom: 8, textAlign: 'center' }}>
+                当前文件: {navFileName}{navUploadTime && ` (上传时间: ${navUploadTime})`}
+              </div>
+            )}
+
+            <div className={styles.buttonGroup}>
+              <button
+                className={`${styles.modeButton} ${selectedMode === 'summary' ? styles.active : ''}`}
+                onClick={() => handleModeSelect('summary')}
+                disabled={!selectedFileId}
+              >信息总结</button>
+              <button
+                className={`${styles.modeButton} ${selectedMode === 'devotional' ? styles.active : ''}`}
+                onClick={() => handleModeSelect('devotional')}
+                disabled={!selectedFileId}
+              >每日灵修</button>
+              <button
+                className={`${styles.modeButton} ${selectedMode === 'bible' ? styles.active : ''}`}
+                onClick={() => handleModeSelect('bible')}
+                disabled={!selectedFileId}
+              >查经指引</button>
+            </div>
+
+            {allFiles.length === 0 && (
+              <div style={{ fontSize: '14px', color: '#ff6b6b', textAlign: 'center', padding: '12px', background: '#fff5f5', borderRadius: '8px', border: '1px solid #ffebee' }}>
+                目前尚无可用文件
+              </div>
+            )}
+
+            <div className={styles.contentWrapper}>
+              {sermonContent ? (
+                <>
+                  <div className={`${styles.contentArea} ${styles.hasContent}`}>
+                    {renderNavContent()}
+                  </div>
+                  <div className={styles.chatSection}>
+                    <div className={chatStyles.chatWrapper}>
+                      <div className={`${chatStyles.sidebar}${sidebarOpen ? ' ' + chatStyles.sidebarOpen : ''}`}>
+                        <button
+                          className={chatStyles.sidebarToggle}
+                          onClick={() => setSidebarOpen(v => !v)}
+                        >
+                          <span>📋 對話記錄</span>
+                          <span>{sidebarOpen ? '▲' : '▼'}</span>
+                        </button>
+                        <ConversationList
+                          userId={user!.user_id}
+                          type="agape-church"
+                          currentThreadId={currentThreadId}
+                          onSelectThread={handleSelectThread}
+                          isCreating={false}
+                          onCreateNewThread={handleCreateNewThread}
+                          sidebarMode={true}
+                        />
+                      </div>
+                      <div className={chatStyles.main}>
+                        <MessageList messages={messages} isLoading={chatLoading} />
+                        {chatError && (
+                          <div style={{ color: '#f55', padding: '6px 16px', background: '#3a0000' }}>
+                            {chatError}
+                          </div>
+                        )}
+                        <ChatInput onSend={handleSendMessage} isLoading={chatLoading} />
+                      </div>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div style={{ textAlign: 'center', width: '100%', padding: '2rem 0', color: '#94a3b8' }}>
+                  <p>请先选择要查看的内容类型</p>
+                </div>
+              )}
+            </div>
           </div>
+
         </div>
       </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Page entry — wraps content with ChatProvider via WithChat
+// ─────────────────────────────────────────────────────────────────
+export default function AgapeChurchPage() {
+  return (
+    <WithChat chatType="agape-church">
+      <AgapeChurchContent />
     </WithChat>
   );
 }

--- a/app/cfsc-church/page.tsx
+++ b/app/cfsc-church/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import SermonInputTabs from '../components/SermonInputTabs';
 import WithChat from '../components/layouts/WithChat';
 import UserIdDisplay from '../components/UserIdDisplay';
 import { useCredit } from '../contexts/CreditContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useChat } from '../contexts/ChatContext';
+import ConversationList from '../components/ConversationList';
+import MessageList from '../components/Chat/MessageList';
+import ChatInput from '../components/Chat/ChatInput';
+import ReactMarkdown from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
+import chatStyles from './navigator/chat.module.css';
 import { getSundayGuideUnitConfig } from '../config/constants';
 
 interface ProcessedContent {
@@ -16,7 +22,9 @@ interface ProcessedContent {
   bibleStudy: string;
 }
 
-export default function CfscChurchPage() {
+type GuideMode = 'summary' | 'devotional' | 'bible' | null;
+
+function CfscChurchContent() {
   const cfscChurchUnit = getSundayGuideUnitConfig('cfscChurch');
   const { refreshUsage, hasInsufficientTokens, remainingCredits } = useCredit();
   const { user } = useAuth();
@@ -37,6 +45,25 @@ export default function CfscChurchPage() {
   const [allowedUploaders, setAllowedUploaders] = useState<string[]>([]);
   const hasUploadPermission = !!user?.user_id && allowedUploaders.includes(user.user_id);
 
+  // ── Navigator states ─────────────────────────────────────────
+  const [selectedMode, setSelectedMode] = useState<GuideMode>(null);
+  const [sermonContent, setSermonContent] = useState<string | null>(null);
+  const [navLoading, setNavLoading] = useState(false);
+  const [navFileName, setNavFileName] = useState<string>('');
+  const [navUploadTime, setNavUploadTime] = useState<string>('');
+  const [pdfLoading, setPdfLoading] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // ── Chat context ─────────────────────────────────────────────
+  const {
+    messages, currentThreadId, setCurrentThreadId, sendMessage,
+    isLoading: chatLoading, error: chatError, setError: setChatError,
+    setMessages, loadChatHistory,
+  } = useChat();
+  const shouldLoadHistory = useRef(false);
+
   useEffect(() => {
     fetch('/api/admin/sunday-guide-units')
       .then((r) => r.json())
@@ -48,6 +75,33 @@ export default function CfscChurchPage() {
 
   useEffect(() => { setIsUploadDisabled(remainingCredits <= 0); }, [remainingCredits, hasInsufficientTokens]);
   useEffect(() => { localStorage.setItem('currentUnitId', 'cfscChurch'); }, []);
+
+  useEffect(() => {
+    if (chatError) {
+      const t = setTimeout(() => setChatError(''), 8000);
+      return () => clearTimeout(t);
+    }
+  }, [chatError, setChatError]);
+
+  useEffect(() => {
+    if (currentThreadId && user && shouldLoadHistory.current) {
+      shouldLoadHistory.current = false;
+      loadChatHistory(user.user_id);
+    }
+  }, [currentThreadId]);
+
+  useEffect(() => {
+    if (allFiles.length === 0) return;
+    const storedId = typeof window !== 'undefined' ? localStorage.getItem('selectedFileId') : null;
+    const storedName = typeof window !== 'undefined' ? localStorage.getItem('selectedFileName') : null;
+    const target = (storedId ? allFiles.find(f => f.fileId === storedId) : null) || allFiles[0];
+    if (!target) return;
+    if (!selectedFileId) setSelectedFileId(target.fileId);
+    const displayName = (!target.fileName.toLowerCase().endsWith('.pdf') && target.sermonTitle)
+      ? target.sermonTitle : target.fileName;
+    setNavFileName(storedName || displayName);
+    setNavUploadTime(target.uploadDate);
+  }, [allFiles]);
 
   const fetchAllFileRecords = async () => {
     try {
@@ -86,7 +140,13 @@ export default function CfscChurchPage() {
         alert('刪除失敗: ' + (data.error || res.status));
       } else {
         await fetchAllFileRecords();
-        if (selectedFileId === fileId) setSelectedFileId(null);
+        if (selectedFileId === fileId) {
+          setSelectedFileId(null);
+          setNavFileName('');
+          setNavUploadTime('');
+          setSermonContent(null);
+          setSelectedMode(null);
+        }
       }
     } catch (e: any) {
       alert('刪除時發生錯誤: ' + (e.message || '未知錯誤'));
@@ -109,6 +169,7 @@ export default function CfscChurchPage() {
       const data = await res.json();
       if (res.ok && data.success) {
         setAllFiles(prev => prev.map(f => f.fileId === fileId ? { ...f, sermonTitle: data.sermonTitle } : f));
+        if (selectedFileId === fileId) setNavFileName(data.sermonTitle || newTitle.trim());
       } else {
         alert('更新失敗: ' + (data.error || res.status));
       }
@@ -127,18 +188,26 @@ export default function CfscChurchPage() {
     await refreshUsage();
   };
 
-  const handleSelectFile = (fileId: string, fileName: string) => {
+  const handleSelectFile = (fileId: string, fileName?: string) => {
     setSelectedFileId(fileId);
+    setSermonContent(null);
+    setSelectedMode(null);
+    const file = recentFiles.find(f => f.fileId === fileId);
+    const displayName = fileName || (file
+      ? ((!file.fileName.toLowerCase().endsWith('.pdf') && file.sermonTitle) ? file.sermonTitle : file.fileName)
+      : '');
+    setNavFileName(displayName);
+    setNavUploadTime(file?.uploadDate || '');
     try {
       localStorage.setItem('selectedFileId', fileId);
-      localStorage.setItem('selectedFileName', fileName);
+      localStorage.setItem('selectedFileName', displayName);
       localStorage.setItem('currentUnitId', 'cfscChurch');
       const channel = new BroadcastChannel('file-selection');
       channel.postMessage({
         type: 'FILE_SELECTED',
         assistantId: cfscChurchUnit.assistantId,
         fileId,
-        fileName,
+        fileName: displayName,
         ts: Date.now(),
       });
       channel.close();
@@ -147,154 +216,235 @@ export default function CfscChurchPage() {
     }
   };
 
+  // ── Navigator functions ──────────────────────────────────────
+  const handleCreateNewThread = () => {
+    setCurrentThreadId(null);
+    setMessages([]);
+  };
+
+  const handleSelectThread = (threadId: string) => {
+    if (threadId === currentThreadId) return;
+    shouldLoadHistory.current = true;
+    setChatError('');
+    setMessages([]);
+    setCurrentThreadId(threadId);
+    setSidebarOpen(false);
+  };
+
+  const handleSendMessage = async (message: string) => {
+    await sendMessage(message);
+    window.dispatchEvent(new CustomEvent('refreshConversations'));
+  };
+
+  const handleModeSelect = async (mode: GuideMode) => {
+    if (!selectedFileId) return;
+    setSelectedMode(mode);
+    setNavLoading(true);
+    try {
+      const userId = user?.user_id || '';
+      const apiUrl = `/api/sunday-guide/content/${cfscChurchUnit.assistantId}?type=${mode}&userId=${encodeURIComponent(userId)}&fileId=${encodeURIComponent(selectedFileId)}`;
+      const response = await fetch(apiUrl);
+      if (response.status === 202) {
+        const data = await response.json().catch(() => ({}));
+        setSelectedMode(null);
+        alert(data.error || '內容正在生成中，請稍候再試');
+        return;
+      }
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({ error: '未知錯誤' }));
+        throw new Error(`获取内容失败: ${response.status} - ${errData.error || response.statusText}`);
+      }
+      const data = await response.json();
+      setSermonContent(data.content);
+      await refreshUsage();
+    } catch (e) {
+      console.error(e);
+      alert(e instanceof Error ? e.message : '請稍後重試');
+    } finally {
+      setNavLoading(false);
+    }
+  };
+
+  const handleDownloadPDF = () => {
+    setPdfError(null);
+    setPdfLoading(true);
+    try {
+      const userId = user?.user_id || '';
+      const params = new URLSearchParams();
+      params.set('assistantId', cfscChurchUnit.assistantId);
+      params.set('userId', userId);
+      params.set('includeAll', 'true');
+      window.open(`/api/sunday-guide/download-pdf?${params.toString()}`, '_blank');
+      setTimeout(() => setPdfLoading(false), 1200);
+    } catch (err) {
+      console.error('PDF 下載失敗', err);
+      setPdfError(err instanceof Error ? err.message : '下載失敗');
+      setPdfLoading(false);
+    }
+  };
+
+  const renderNavContent = () => {
+    if (navLoading) return <div className={styles.loading}>加载中，请稍候...</div>;
+    if (!sermonContent) return null;
+    const titles: Record<string, string> = { summary: '讲道总结', devotional: '每日灵修', bible: '查经指引' };
+    return (
+      <div className={styles.contentBox}>
+        <div className={styles.contentHeader}>
+          <h2>{titles[selectedMode!]}</h2>
+          <button className={styles.downloadButton} onClick={handleDownloadPDF} disabled={pdfLoading}>
+            {pdfLoading ? '生成中...' : '下载完整版'}
+          </button>
+        </div>
+        {pdfError && <div className={styles.errorMessage}>{pdfError}</div>}
+        <div className={styles.markdownContent} ref={contentRef}>
+          <ReactMarkdown>{sermonContent}</ReactMarkdown>
+        </div>
+      </div>
+    );
+  };
+
   return (
-    <WithChat chatType="sunday-guide">
-      <div className={styles.container}>
-        <UserIdDisplay />
+    <div className={styles.container}>
+      <UserIdDisplay />
 
-        {/* =============== 1. Upload Section =============== */}
-        {hasUploadPermission && (
-          <section className={styles.uploadHero}>
-            <h2 className={styles.uploadHeroTitle}>上传讲章</h2>
-            <p className={styles.uploadHeroDesc}>
-              上传主日讲章文件，系统将自动生成<strong>信息总结</strong>、<strong>每日灵修</strong>与<strong>查经指引</strong>。
-              <br />
-              支持格式：<strong>PDF / 文件</strong>、<strong>YouTube 链接</strong>、<strong>音频文件</strong>
-            </p>
+      {/* ═══ 1. Upload Section ═══ */}
+      {hasUploadPermission && (
+        <section className={styles.uploadHero}>
+          <h2 className={styles.uploadHeroTitle}>上传讲章</h2>
+          <p className={styles.uploadHeroDesc}>
+            上传主日讲章文件，系统将自动生成<strong>信息总结</strong>、<strong>每日灵修</strong>与<strong>查经指引</strong>。
+            <br />
+            支持格式：<strong>PDF / 文件</strong>、<strong>YouTube 链接</strong>、<strong>音频文件</strong>
+          </p>
+          {isUploadDisabled && <span className={styles.creditWarningInline}>额度不足，无法上传</span>}
+          {!isUploadDisabled && remainingCredits > 0 && remainingCredits < 20 && (
+            <span className={styles.creditWarningInline} style={{ background: '#fef3c7', color: '#92400e' }}>
+              余额较低 ({remainingCredits})
+            </span>
+          )}
+          <div className={styles.uploadArea}>
+            <SermonInputTabs
+              onFileProcessed={handleFileProcessed}
+              setIsProcessing={setIsProcessing}
+              setUploadProgress={setUploadProgress}
+              setUploadTime={setUploadTime}
+              disabled={isUploadDisabled}
+              assistantId={cfscChurchUnit.assistantId}
+              vectorStoreId={cfscChurchUnit.vectorStoreId}
+              unitId="cfscChurch"
+            />
+          </div>
+          {isProcessing && <div className={styles.processingAlert}><p>处理中，约需 3-5 分钟，请勿关闭页面...</p></div>}
+          {uploadTime && <span className={styles.uploadTimeBadge}>✓ 完成于 {uploadTime}</span>}
+        </section>
+      )}
 
-            {isUploadDisabled && (
-              <span className={styles.creditWarningInline}>额度不足，无法上传</span>
-            )}
-            {!isUploadDisabled && remainingCredits > 0 && remainingCredits < 20 && (
-              <span className={styles.creditWarningInline} style={{ background: '#fef3c7', color: '#92400e' }}>
-                余额较低 ({remainingCredits})
-              </span>
-            )}
+      {/* ═══ 2. Main Layout ═══ */}
+      <div className={styles.mainLayout}>
+        {/* ── Left: Document List ── */}
+        <aside className={styles.docsSection}>
+          <h4 className={styles.docsSectionTitle}>
+            📚 文档列表
+            <span className={styles.docsSectionHint}>— 选择一份讲章</span>
+          </h4>
+          {recentFiles.length === 0 ? (
+            <div className={styles.noDocs}>暂无文档</div>
+          ) : (
+            <>
+              <ul className={styles.docsListScrollable}>
+                {recentFiles.map((file, idx) => (
+                  <li
+                    key={file.fileId || idx}
+                    className={`${styles.docItem} ${selectedFileId === file.fileId ? styles.docItemSelected : ''}`}
+                    onClick={() => handleSelectFile(file.fileId)}
+                    title="点击选择此文档"
+                  >
+                    {(user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id))) ? (
+                      <button onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }} disabled={deletingId === file.fileId} className={styles.deleteButton} title="删除此文档">
+                        {deletingId === file.fileId ? '...' : '×'}
+                      </button>
+                    ) : <span className={styles.deleteButtonPlaceholder} />}
+                    <span className={styles.docIndex}>{(currentPage - 1) * filesPerPage + idx + 1}.</span>
+                    {editingFileId === file.fileId ? (
+                      <input className={styles.docTitleInput} value={editingTitle} autoFocus
+                        onChange={e => setEditingTitle(e.target.value)}
+                        onBlur={() => handleRenameTitle(file.fileId, editingTitle)}
+                        onKeyDown={e => { if (e.key === 'Enter') handleRenameTitle(file.fileId, editingTitle); if (e.key === 'Escape') setEditingFileId(null); }}
+                        onClick={e => e.stopPropagation()} />
+                    ) : (
+                      <>
+                        <span className={styles.docFileName}>{file.fileName.toLowerCase().endsWith('.pdf') ? file.fileName : (file.sermonTitle || file.fileName)}</span>
+                        {user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id)) && (
+                          <button className={styles.editTitleButton} title="編輯標題" onClick={e => { e.stopPropagation(); setEditingTitle(file.sermonTitle || file.fileName); setEditingFileId(file.fileId); }}>✎</button>
+                        )}
+                      </>
+                    )}
+                    <span className={styles.docDate}>{file.uploadDate}</span>
+                  </li>
+                ))}
+              </ul>
+              {allFiles.length > 0 && (
+                <div className={styles.pagination}>
+                  <button onClick={() => setCurrentPage((p) => Math.max(1, p - 1))} disabled={currentPage === 1} className={styles.paginationButton}>←</button>
+                  <span className={styles.paginationInfo}>{currentPage} / {totalPages}</span>
+                  <button onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages} className={styles.paginationButton}>→</button>
+                </div>
+              )}
+            </>
+          )}
+        </aside>
 
-            <div className={styles.uploadArea}>
-              <SermonInputTabs
-                onFileProcessed={handleFileProcessed}
-                setIsProcessing={setIsProcessing}
-                setUploadProgress={setUploadProgress}
-                setUploadTime={setUploadTime}
-                disabled={isUploadDisabled}
-                assistantId={cfscChurchUnit.assistantId}
-                vectorStoreId={cfscChurchUnit.vectorStoreId}
-                unitId="cfscChurch"
-              />
+        {/* ── Right: Navigator Panel ── */}
+        <div className={styles.navigatorPanel}>
+          <h2 style={{ textAlign: 'center', fontSize: '1.1rem', fontWeight: 700, color: '#1e293b', margin: '0 0 0.5rem' }}>主日信息导航</h2>
+          {navFileName && (
+            <div style={{ fontSize: '13px', color: '#0070f3', marginBottom: 8, textAlign: 'center' }}>
+              当前文件: {navFileName}{navUploadTime && ` (上传时间: ${navUploadTime})`}
             </div>
-
-            {isProcessing && (
-              <div className={styles.processingAlert}>
-                <p>处理中，约需 3-5 分钟，请勿关闭页面...</p>
-              </div>
-            )}
-            {uploadTime && (
-              <span className={styles.uploadTimeBadge}>✓ 完成于 {uploadTime}</span>
-            )}
-          </section>
-        )}
-
-        {/* =============== 2. Sidebar + Placeholder =============== */}
-        <div className={styles.mainLayout}>
-          <aside className={styles.docsSection}>
-            <h4 className={styles.docsSectionTitle}>
-              📚 文档列表
-              <span className={styles.docsSectionHint}>— 选择一份讲章</span>
-            </h4>
-
-            {recentFiles.length === 0 ? (
-              <div className={styles.noDocs}>暂无文档</div>
-            ) : (
+          )}
+          <div className={styles.buttonGroup}>
+            <button className={`${styles.modeButton} ${selectedMode === 'summary' ? styles.active : ''}`} onClick={() => handleModeSelect('summary')} disabled={!selectedFileId}>信息总结</button>
+            <button className={`${styles.modeButton} ${selectedMode === 'devotional' ? styles.active : ''}`} onClick={() => handleModeSelect('devotional')} disabled={!selectedFileId}>每日灵修</button>
+            <button className={`${styles.modeButton} ${selectedMode === 'bible' ? styles.active : ''}`} onClick={() => handleModeSelect('bible')} disabled={!selectedFileId}>查经指引</button>
+          </div>
+          {allFiles.length === 0 && (
+            <div style={{ fontSize: '14px', color: '#ff6b6b', textAlign: 'center', padding: '12px', background: '#fff5f5', borderRadius: '8px', border: '1px solid #ffebee' }}>目前尚无可用文件</div>
+          )}
+          <div className={styles.contentWrapper}>
+            {sermonContent ? (
               <>
-                <ul className={styles.docsListScrollable}>
-                  {recentFiles.map((file, idx) => (
-                    <li
-                      key={file.fileId || idx}
-                      className={`${styles.docItem} ${selectedFileId === file.fileId ? styles.docItemSelected : ''}`}
-                      onClick={() => handleSelectFile(file.fileId, file.fileName.toLowerCase().endsWith('.pdf') ? file.fileName : (file.sermonTitle || file.fileName))}
-                      title="点击选择此文档"
-                    >
-                      {(user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id))) ? (
-                        <button
-                          onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }}
-                          disabled={deletingId === file.fileId}
-                          className={styles.deleteButton}
-                          title="删除此文档"
-                        >
-                          {deletingId === file.fileId ? '...' : '×'}
-                        </button>
-                      ) : (
-                        <span className={styles.deleteButtonPlaceholder} />
-                      )}
-                      <span className={styles.docIndex}>{(currentPage - 1) * filesPerPage + idx + 1}.</span>
-                      {editingFileId === file.fileId ? (
-                        <input
-                          className={styles.docTitleInput}
-                          value={editingTitle}
-                          autoFocus
-                          onChange={e => setEditingTitle(e.target.value)}
-                          onBlur={() => handleRenameTitle(file.fileId, editingTitle)}
-                          onKeyDown={e => {
-                            if (e.key === 'Enter') handleRenameTitle(file.fileId, editingTitle);
-                            if (e.key === 'Escape') setEditingFileId(null);
-                          }}
-                          onClick={e => e.stopPropagation()}
-                        />
-                      ) : (
-                        <>
-                          <span className={styles.docFileName}>{file.fileName.toLowerCase().endsWith('.pdf') ? file.fileName : (file.sermonTitle || file.fileName)}</span>
-                          {user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id)) && (
-                            <button
-                              className={styles.editTitleButton}
-                              title="編輯標題"
-                              onClick={e => {
-                                e.stopPropagation();
-                                setEditingTitle(file.sermonTitle || file.fileName);
-                                setEditingFileId(file.fileId);
-                              }}
-                            >✎</button>
-                          )}
-                        </>
-                      )}
-                      <span className={styles.docDate}>{file.uploadDate}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                {allFiles.length > 0 && (
-                  <div className={styles.pagination}>
-                    <button
-                      onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                      disabled={currentPage === 1}
-                      className={styles.paginationButton}
-                    >
-                      ←
-                    </button>
-                    <span className={styles.paginationInfo}>{currentPage} / {totalPages}</span>
-                    <button
-                      onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                      disabled={currentPage === totalPages}
-                      className={styles.paginationButton}
-                    >
-                      →
-                    </button>
+                <div className={`${styles.contentArea} ${styles.hasContent}`}>{renderNavContent()}</div>
+                <div className={styles.chatSection}>
+                  <div className={chatStyles.chatWrapper}>
+                    <div className={`${chatStyles.sidebar}${sidebarOpen ? ' ' + chatStyles.sidebarOpen : ''}`}>
+                      <button className={chatStyles.sidebarToggle} onClick={() => setSidebarOpen(v => !v)}>
+                        <span>📋 對話記錄</span><span>{sidebarOpen ? '▲' : '▼'}</span>
+                      </button>
+                      <ConversationList userId={user!.user_id} type="cfsc-church" currentThreadId={currentThreadId}
+                        onSelectThread={handleSelectThread} isCreating={false} onCreateNewThread={handleCreateNewThread} sidebarMode={true} />
+                    </div>
+                    <div className={chatStyles.main}>
+                      <MessageList messages={messages} isLoading={chatLoading} />
+                      {chatError && <div style={{ color: '#f55', padding: '6px 16px', background: '#3a0000' }}>{chatError}</div>}
+                      <ChatInput onSend={handleSendMessage} isLoading={chatLoading} />
+                    </div>
                   </div>
-                )}
+                </div>
               </>
+            ) : (
+              <div style={{ textAlign: 'center', width: '100%', padding: '2rem 0', color: '#94a3b8' }}><p>请先选择要查看的内容类型</p></div>
             )}
-          </aside>
-
-          <div className={styles.guidePlaceholder}>
-            <div className={styles.guidePlaceholderIcon}>👈</div>
-            <p className={styles.guidePlaceholderText}>
-              选择讲章后可前往<br />
-              <a href="/cfsc-church/navigator" style={{ color: '#0070f3', textDecoration: 'underline' }}>CFSC Church 信息導覽</a><br />
-              查看信息总结、灵修与查经
-            </p>
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+export default function CfscChurchPage() {
+  return (
+    <WithChat chatType="cfsc-church">
+      <CfscChurchContent />
     </WithChat>
   );
 }

--- a/app/chinese-pastor-network/page.tsx
+++ b/app/chinese-pastor-network/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import SermonInputTabs from '../components/SermonInputTabs';
 import WithChat from '../components/layouts/WithChat';
 import UserIdDisplay from '../components/UserIdDisplay';
 import { useCredit } from '../contexts/CreditContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useChat } from '../contexts/ChatContext';
+import ConversationList from '../components/ConversationList';
+import MessageList from '../components/Chat/MessageList';
+import ChatInput from '../components/Chat/ChatInput';
+import ReactMarkdown from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
+import chatStyles from './navigator/chat.module.css';
 import { ASSISTANT_IDS, VECTOR_STORE_IDS } from '../config/constants';
 
 interface ProcessedContent {
@@ -16,11 +22,12 @@ interface ProcessedContent {
   bibleStudy: string;
 }
 
-export default function ChinesePastorNetworkPage() {
+type GuideMode = 'summary' | 'devotional' | 'bible' | null;
+
+function ChinesePastorNetworkContent() {
   const { refreshUsage, hasInsufficientTokens, remainingCredits } = useCredit();
   const { user } = useAuth();
   const [isProcessing, setIsProcessing] = useState(false);
-  const [processedContent, setProcessedContent] = useState<ProcessedContent | null>(null);
   const [uploadProgress, setUploadProgress] = useState<number>(0);
   const [uploadTime, setUploadTime] = useState<string>('');
   const [isUploadDisabled, setIsUploadDisabled] = useState(false);
@@ -37,6 +44,23 @@ export default function ChinesePastorNetworkPage() {
   const [allowedUploaders, setAllowedUploaders] = useState<string[]>([]);
   const hasUploadPermission = !!user?.user_id && allowedUploaders.includes(user.user_id);
 
+  const [selectedMode, setSelectedMode] = useState<GuideMode>(null);
+  const [sermonContent, setSermonContent] = useState<string | null>(null);
+  const [navLoading, setNavLoading] = useState(false);
+  const [navFileName, setNavFileName] = useState<string>('');
+  const [navUploadTime, setNavUploadTime] = useState<string>('');
+  const [pdfLoading, setPdfLoading] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const {
+    messages, currentThreadId, setCurrentThreadId, sendMessage,
+    isLoading: chatLoading, error: chatError, setError: setChatError,
+    setMessages, loadChatHistory,
+  } = useChat();
+  const shouldLoadHistory = useRef(false);
+
   useEffect(() => {
     fetch('/api/admin/sunday-guide-units')
       .then((r) => r.json())
@@ -47,6 +71,26 @@ export default function ChinesePastorNetworkPage() {
   }, []);
 
   useEffect(() => { setIsUploadDisabled(remainingCredits <= 0); }, [remainingCredits, hasInsufficientTokens]);
+
+  useEffect(() => {
+    if (chatError) { const t = setTimeout(() => setChatError(''), 8000); return () => clearTimeout(t); }
+  }, [chatError, setChatError]);
+
+  useEffect(() => {
+    if (currentThreadId && user && shouldLoadHistory.current) { shouldLoadHistory.current = false; loadChatHistory(user.user_id); }
+  }, [currentThreadId]);
+
+  useEffect(() => {
+    if (allFiles.length === 0) return;
+    const storedId = typeof window !== 'undefined' ? localStorage.getItem('selectedFileId') : null;
+    const storedName = typeof window !== 'undefined' ? localStorage.getItem('selectedFileName') : null;
+    const target = (storedId ? allFiles.find(f => f.fileId === storedId) : null) || allFiles[0];
+    if (!target) return;
+    if (!selectedFileId) setSelectedFileId(target.fileId);
+    const displayName = (!target.fileName.toLowerCase().endsWith('.pdf') && target.sermonTitle) ? target.sermonTitle : target.fileName;
+    setNavFileName(storedName || displayName);
+    setNavUploadTime(target.uploadDate);
+  }, [allFiles]);
 
   const fetchAllFileRecords = async () => {
     try {
@@ -108,6 +152,7 @@ export default function ChinesePastorNetworkPage() {
       const data = await res.json();
       if (res.ok && data.success) {
         setAllFiles(prev => prev.map(f => f.fileId === fileId ? { ...f, sermonTitle: data.sermonTitle } : f));
+        if (selectedFileId === fileId) setNavFileName(data.sermonTitle || newTitle.trim());
       } else {
         alert('更新失敗: ' + (data.error || res.status));
       }
@@ -120,8 +165,7 @@ export default function ChinesePastorNetworkPage() {
 
   useEffect(() => { fetchAllFileRecords(); }, [user]);
 
-  const handleFileProcessed = async (content: ProcessedContent) => {
-    setProcessedContent(content);
+  const handleFileProcessed = async (_content: ProcessedContent) => {
     setIsProcessing(false);
     await fetchAllFileRecords();
     await refreshUsage();
@@ -129,173 +173,168 @@ export default function ChinesePastorNetworkPage() {
 
   const handleSelectFile = (fileId: string) => {
     setSelectedFileId(fileId);
+    setSermonContent(null);
+    setSelectedMode(null);
+    const file = recentFiles.find(f => f.fileId === fileId);
+    const displayName = file
+      ? ((!file.fileName.toLowerCase().endsWith('.pdf') && file.sermonTitle) ? file.sermonTitle : file.fileName)
+      : '';
+    setNavFileName(displayName);
+    setNavUploadTime(file?.uploadDate || '');
     try {
-      const file = recentFiles.find(f => f.fileId === fileId);
       localStorage.setItem('selectedFileId', fileId);
       if (file) localStorage.setItem('selectedFileName', file.fileName);
       const channel = new BroadcastChannel('file-selection');
-      channel.postMessage({
-        type: 'FILE_SELECTED',
-        assistantId: ASSISTANT_IDS.CHINESE_PASTOR_NETWORK,
-        fileId,
-        fileName: file?.fileName || '',
-        ts: Date.now(),
-      });
+      channel.postMessage({ type: 'FILE_SELECTED', assistantId: ASSISTANT_IDS.CHINESE_PASTOR_NETWORK, fileId, fileName: file?.fileName || '', ts: Date.now() });
       channel.close();
-    } catch (err) {
-      console.warn('broadcast file selection failed', err);
-    }
+    } catch (err) { console.warn('broadcast file selection failed', err); }
+  };
+
+  const handleCreateNewThread = () => { setCurrentThreadId(null); setMessages([]); };
+  const handleSelectThread = (threadId: string) => {
+    if (threadId === currentThreadId) return;
+    shouldLoadHistory.current = true; setChatError(''); setMessages([]); setCurrentThreadId(threadId); setSidebarOpen(false);
+  };
+  const handleSendMessage = async (message: string) => { await sendMessage(message); window.dispatchEvent(new CustomEvent('refreshConversations')); };
+  const handleModeSelect = async (mode: GuideMode) => {
+    if (!selectedFileId) return;
+    setSelectedMode(mode); setNavLoading(true);
+    try {
+      const userId = user?.user_id || '';
+      const response = await fetch(`/api/sunday-guide/content/${ASSISTANT_IDS.CHINESE_PASTOR_NETWORK}?type=${mode}&userId=${encodeURIComponent(userId)}&fileId=${encodeURIComponent(selectedFileId)}`);
+      if (response.status === 202) { const data = await response.json().catch(() => ({})); setSelectedMode(null); alert(data.error || '內容正在生成中，請稍候再試'); return; }
+      if (!response.ok) { const errData = await response.json().catch(() => ({ error: '未知錯誤' })); throw new Error(`获取内容失败: ${response.status} - ${errData.error}`); }
+      const data = await response.json();
+      setSermonContent(data.content);
+      await refreshUsage();
+    } catch (e) { console.error(e); alert(e instanceof Error ? e.message : '請稍後重試'); }
+    finally { setNavLoading(false); }
+  };
+  const handleDownloadPDF = () => {
+    setPdfError(null); setPdfLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set('assistantId', ASSISTANT_IDS.CHINESE_PASTOR_NETWORK);
+      params.set('userId', user?.user_id || '');
+      params.set('includeAll', 'true');
+      window.open(`/api/sunday-guide/download-pdf?${params.toString()}`, '_blank');
+      setTimeout(() => setPdfLoading(false), 1200);
+    } catch (err) { setPdfError(err instanceof Error ? err.message : '下載失敗'); setPdfLoading(false); }
+  };
+  const renderNavContent = () => {
+    if (navLoading) return <div className={styles.loading}>加载中，请稍候...</div>;
+    if (!sermonContent) return null;
+    const titles: Record<string, string> = { summary: '讲道总结', devotional: '每日灵修', bible: '查经指引' };
+    return (
+      <div className={styles.contentBox}>
+        <div className={styles.contentHeader}>
+          <h2>{titles[selectedMode!]}</h2>
+          <button className={styles.downloadButton} onClick={handleDownloadPDF} disabled={pdfLoading}>{pdfLoading ? '生成中...' : '下载完整版'}</button>
+        </div>
+        {pdfError && <div className={styles.errorMessage}>{pdfError}</div>}
+        <div className={styles.markdownContent} ref={contentRef}><ReactMarkdown>{sermonContent}</ReactMarkdown></div>
+      </div>
+    );
   };
 
   return (
-    <WithChat chatType="sunday-guide">
-      <div className={styles.container}>
-        <UserIdDisplay />
-
-        {/* =============== 1. Upload Section =============== */}
-        {hasUploadPermission && (
-          <section className={styles.uploadHero}>
-            <h2 className={styles.uploadHeroTitle}>上传讲章</h2>
-            <p className={styles.uploadHeroDesc}>
-              上传华牧网络教会事工联盟讲章文件，系统将自动生成<strong>信息总结</strong>、<strong>每日灵修</strong>与<strong>查经指引</strong>。
-              <br />
-              支持格式：<strong>PDF / 文件</strong>、<strong>YouTube 链接</strong>、<strong>音频文件</strong>
-            </p>
-
-            {isUploadDisabled && (
-              <span className={styles.creditWarningInline}>额度不足，无法上传</span>
-            )}
-            {!isUploadDisabled && remainingCredits > 0 && remainingCredits < 20 && (
-              <span className={styles.creditWarningInline} style={{ background: '#fef3c7', color: '#92400e' }}>
-                余额较低 ({remainingCredits})
-              </span>
-            )}
-
-            <div className={styles.uploadArea}>
-              <SermonInputTabs
-                onFileProcessed={handleFileProcessed}
-                setIsProcessing={setIsProcessing}
-                setUploadProgress={setUploadProgress}
-                setUploadTime={setUploadTime}
-                disabled={isUploadDisabled}
-                assistantId={ASSISTANT_IDS.CHINESE_PASTOR_NETWORK}
-                vectorStoreId={VECTOR_STORE_IDS.CHINESE_PASTOR_NETWORK}
-                unitId="chinesePastorNetwork"
-              />
-            </div>
-
-            {isProcessing && (
-              <div className={styles.processingAlert}>
-                <p>处理中，约需 3-5 分钟，请勿关闭页面...</p>
-              </div>
-            )}
-            {uploadTime && (
-              <span className={styles.uploadTimeBadge}>✓ 完成于 {uploadTime}</span>
-            )}
-          </section>
-        )}
-
-        {/* =============== 2. Sidebar: 文檔列表 =============== */}
-        <div className={styles.mainLayout}>
-          <aside className={styles.docsSection}>
-            <h4 className={styles.docsSectionTitle}>
-              📚 文档列表
-              <span className={styles.docsSectionHint}>— 选择一份讲章</span>
-              <span style={{ fontSize: '0.7em', fontWeight: 'normal', color: '#888', marginLeft: '6px' }}>按上传日期↓</span>
-            </h4>
-
-            {recentFiles.length === 0 ? (
-              <div className={styles.noDocs}>暂无文档</div>
-            ) : (
-              <>
-                <ul className={styles.docsListScrollable}>
-                  {recentFiles.map((file, idx) => (
-                    <li
-                      key={file.fileId || idx}
-                      className={`${styles.docItem} ${selectedFileId === file.fileId ? styles.docItemSelected : ''}`}
-                      onClick={() => handleSelectFile(file.fileId)}
-                      title="点击选择此文档"
-                    >
-                      {(user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id))) ? (
-                        <button
-                          onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }}
-                          disabled={deletingId === file.fileId}
-                          className={styles.deleteButton}
-                          title="删除此文档"
-                        >
-                          {deletingId === file.fileId ? '...' : '×'}
-                        </button>
-                      ) : (
-                        <span className={styles.deleteButtonPlaceholder} />
-                      )}
-                      <span className={styles.docIndex}>{(currentPage - 1) * filesPerPage + idx + 1}.</span>
-                      {editingFileId === file.fileId ? (
-                        <input
-                          className={styles.docTitleInput}
-                          value={editingTitle}
-                          autoFocus
-                          onChange={e => setEditingTitle(e.target.value)}
+    <div className={styles.container}>
+      <UserIdDisplay />
+      {hasUploadPermission && (
+        <section className={styles.uploadHero}>
+          <h2 className={styles.uploadHeroTitle}>上传讲章</h2>
+          <p className={styles.uploadHeroDesc}>上传华牧网络教会事工联盟讲章文件，系统将自动生成<strong>信息总结</strong>、<strong>每日灵修</strong>与<strong>查经指引</strong>。<br />支持格式：<strong>PDF / 文件</strong>、<strong>YouTube 链接</strong>、<strong>音频文件</strong></p>
+          {isUploadDisabled && <span className={styles.creditWarningInline}>额度不足，无法上传</span>}
+          {!isUploadDisabled && remainingCredits > 0 && remainingCredits < 20 && (<span className={styles.creditWarningInline} style={{ background: '#fef3c7', color: '#92400e' }}>余额较低 ({remainingCredits})</span>)}
+          <div className={styles.uploadArea}>
+            <SermonInputTabs onFileProcessed={handleFileProcessed} setIsProcessing={setIsProcessing} setUploadProgress={setUploadProgress} setUploadTime={setUploadTime} disabled={isUploadDisabled} assistantId={ASSISTANT_IDS.CHINESE_PASTOR_NETWORK} vectorStoreId={VECTOR_STORE_IDS.CHINESE_PASTOR_NETWORK} unitId="chinesePastorNetwork" />
+          </div>
+          {isProcessing && <div className={styles.processingAlert}><p>处理中，约需 3-5 分钟，请勿关闭页面...</p></div>}
+          {uploadTime && <span className={styles.uploadTimeBadge}>✓ 完成于 {uploadTime}</span>}
+        </section>
+      )}
+      <div className={styles.mainLayout}>
+        <aside className={styles.docsSection}>
+          <h4 className={styles.docsSectionTitle}>📚 文档列表<span className={styles.docsSectionHint}>— 选择一份讲章</span><span style={{ fontSize: '0.7em', fontWeight: 'normal', color: '#888', marginLeft: '6px' }}>按上传日期↓</span></h4>
+          {recentFiles.length === 0 ? <div className={styles.noDocs}>暂无文档</div> : (
+            <>
+              <ul className={styles.docsListScrollable}>
+                {recentFiles.map((file, idx) => (
+                  <li key={file.fileId || idx} className={`${styles.docItem} ${selectedFileId === file.fileId ? styles.docItemSelected : ''}`}
+                    onClick={() => handleSelectFile(file.fileId)} title="点击选择此文档">
+                    {(user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id)))
+                      ? <button onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }} disabled={deletingId === file.fileId} className={styles.deleteButton}>{deletingId === file.fileId ? '...' : '×'}</button>
+                      : <span className={styles.deleteButtonPlaceholder} />}
+                    <span className={styles.docIndex}>{(currentPage - 1) * filesPerPage + idx + 1}.</span>
+                    {editingFileId === file.fileId
+                      ? <input className={styles.docTitleInput} value={editingTitle} autoFocus onChange={e => setEditingTitle(e.target.value)}
                           onBlur={() => handleRenameTitle(file.fileId, editingTitle)}
-                          onKeyDown={e => {
-                            if (e.key === 'Enter') handleRenameTitle(file.fileId, editingTitle);
-                            if (e.key === 'Escape') setEditingFileId(null);
-                          }}
-                          onClick={e => e.stopPropagation()}
-                        />
-                      ) : (
-                        <>
-                          <span className={styles.docFileName}>{file.fileName.toLowerCase().endsWith('.pdf') ? file.fileName : (file.sermonTitle || file.fileName)}</span>
+                          onKeyDown={e => { if (e.key === 'Enter') handleRenameTitle(file.fileId, editingTitle); if (e.key === 'Escape') setEditingFileId(null); }}
+                          onClick={e => e.stopPropagation()} />
+                      : <><span className={styles.docFileName}>{file.fileName.toLowerCase().endsWith('.pdf') ? file.fileName : (file.sermonTitle || file.fileName)}</span>
                           {user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id)) && (
-                            <button
-                              className={styles.editTitleButton}
-                              title="編輯標題"
-                              onClick={e => {
-                                e.stopPropagation();
-                                setEditingTitle(file.sermonTitle || file.fileName);
-                                setEditingFileId(file.fileId);
-                              }}
-                            >✎</button>
-                          )}
-                        </>
-                      )}
-                      <span className={styles.docDate}>{file.uploadDate}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                {allFiles.length > 0 && (
-                  <div className={styles.pagination}>
-                    <button
-                      onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                      disabled={currentPage === 1}
-                      className={styles.paginationButton}
-                    >
-                      ←
-                    </button>
-                    <span className={styles.paginationInfo}>{currentPage} / {totalPages}</span>
-                    <button
-                      onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                      disabled={currentPage === totalPages}
-                      className={styles.paginationButton}
-                    >
-                      →
-                    </button>
+                            <button className={styles.editTitleButton} onClick={e => { e.stopPropagation(); setEditingTitle(file.sermonTitle || file.fileName); setEditingFileId(file.fileId); }}>✎</button>
+                          )}</>
+                    }
+                    <span className={styles.docDate}>{file.uploadDate}</span>
+                  </li>
+                ))}
+              </ul>
+              {allFiles.length > 0 && (
+                <div className={styles.pagination}>
+                  <button onClick={() => setCurrentPage((p) => Math.max(1, p - 1))} disabled={currentPage === 1} className={styles.paginationButton}>←</button>
+                  <span className={styles.paginationInfo}>{currentPage} / {totalPages}</span>
+                  <button onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages} className={styles.paginationButton}>→</button>
+                </div>
+              )}
+            </>
+          )}
+        </aside>
+        <div className={styles.navigatorPanel}>
+          <h2 style={{ textAlign: 'center', fontSize: '1.1rem', fontWeight: 700, color: '#1e293b', margin: '0 0 0.5rem' }}>主日信息导航</h2>
+          {navFileName && <div style={{ fontSize: '13px', color: '#0070f3', marginBottom: 8, textAlign: 'center' }}>当前文件: {navFileName}{navUploadTime && ` (上传时间: ${navUploadTime})`}</div>}
+          <div className={styles.buttonGroup}>
+            <button className={`${styles.modeButton} ${selectedMode === 'summary' ? styles.active : ''}`} onClick={() => handleModeSelect('summary')} disabled={!selectedFileId}>信息总结</button>
+            <button className={`${styles.modeButton} ${selectedMode === 'devotional' ? styles.active : ''}`} onClick={() => handleModeSelect('devotional')} disabled={!selectedFileId}>每日灵修</button>
+            <button className={`${styles.modeButton} ${selectedMode === 'bible' ? styles.active : ''}`} onClick={() => handleModeSelect('bible')} disabled={!selectedFileId}>查经指引</button>
+          </div>
+          {allFiles.length === 0 && <div style={{ fontSize: '14px', color: '#ff6b6b', textAlign: 'center', padding: '12px', background: '#fff5f5', borderRadius: '8px', border: '1px solid #ffebee' }}>目前尚无可用文件</div>}
+          <div className={styles.contentWrapper}>
+            {sermonContent ? (
+              <>
+                <div className={`${styles.contentArea} ${styles.hasContent}`}>{renderNavContent()}</div>
+                <div className={styles.chatSection}>
+                  <div className={chatStyles.chatWrapper}>
+                    <div className={`${chatStyles.sidebar}${sidebarOpen ? ' ' + chatStyles.sidebarOpen : ''}`}>
+                      <button className={chatStyles.sidebarToggle} onClick={() => setSidebarOpen(v => !v)}>
+                        <span>📋 對話記錄</span><span>{sidebarOpen ? '▲' : '▼'}</span>
+                      </button>
+                      <ConversationList userId={user!.user_id} type="chinese-pastor-network" currentThreadId={currentThreadId}
+                        onSelectThread={handleSelectThread} isCreating={false} onCreateNewThread={handleCreateNewThread} sidebarMode={true} />
+                    </div>
+                    <div className={chatStyles.main}>
+                      <MessageList messages={messages} isLoading={chatLoading} />
+                      {chatError && <div style={{ color: '#f55', padding: '6px 16px', background: '#3a0000' }}>{chatError}</div>}
+                      <ChatInput onSend={handleSendMessage} isLoading={chatLoading} />
+                    </div>
                   </div>
-                )}
+                </div>
               </>
+            ) : (
+              <div style={{ textAlign: 'center', width: '100%', padding: '2rem 0', color: '#94a3b8' }}><p>请先选择要查看的内容类型</p></div>
             )}
-          </aside>
-
-          <div className={styles.guidePlaceholder}>
-            <div className={styles.guidePlaceholderIcon}>👈</div>
-            <p className={styles.guidePlaceholderText}>
-              选择讲章后可前往<br />
-              <a href="/chinese-pastor-network/navigator" style={{ color: '#0070f3', textDecoration: 'underline' }}>华牧网络信息導覽</a><br />
-              查看信息总结、灵修与查经
-            </p>
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+export default function ChinesePastorNetworkPage() {
+  return (
+    <WithChat chatType="chinese-pastor-network">
+      <ChinesePastorNetworkContent />
     </WithChat>
   );
 }
+

--- a/app/components/Chat/ChatInput.module.css
+++ b/app/components/Chat/ChatInput.module.css
@@ -47,17 +47,16 @@
   color: #6b7280;
 }
 
-/* 泡泡狀發送按鈕 */
+/* 圓形箭頭發送按鈕 */
 .sendButton {
   flex: 0 0 auto;
   background: var(--chat-send-btn-bg, #4a5fc1);
   color: var(--chat-new-btn-color, white);
   border: none;
-  border-radius: 18px 18px 18px 4px;
-  padding: 0 18px;
+  border-radius: 50%;
+  width: 42px;
   height: 42px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -66,7 +65,6 @@
   align-self: flex-end;
   margin-bottom: 6px;
   flex-shrink: 0;
-  white-space: nowrap;
 }
 
 .sendButton:hover:not(:disabled) {

--- a/app/components/Chat/ChatInput.tsx
+++ b/app/components/Chat/ChatInput.tsx
@@ -79,7 +79,9 @@ export default function ChatInput({ onSend, isLoading }: ChatInputProps) {
         disabled={!input.trim() || isLoading}
         title="發送 (Enter)"
       >
-        發送
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+          <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+        </svg>
       </button>
     </div>
   );

--- a/app/east-christ-home/page.tsx
+++ b/app/east-christ-home/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import SermonInputTabs from '../components/SermonInputTabs';
 import WithChat from '../components/layouts/WithChat';
 import UserIdDisplay from '../components/UserIdDisplay';
 import { useCredit } from '../contexts/CreditContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useChat } from '../contexts/ChatContext';
+import ConversationList from '../components/ConversationList';
+import MessageList from '../components/Chat/MessageList';
+import ChatInput from '../components/Chat/ChatInput';
+import ReactMarkdown from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
+import chatStyles from './navigator/chat.module.css';
 import { getSundayGuideUnitConfig } from '../config/constants';
 
 interface ProcessedContent {
@@ -16,7 +22,9 @@ interface ProcessedContent {
   bibleStudy: string;
 }
 
-export default function EastChristHomePage() {
+type GuideMode = 'summary' | 'devotional' | 'bible' | null;
+
+function EastChristHomeContent() {
   const eastUnit = getSundayGuideUnitConfig('eastChristHome');
   const { refreshUsage, hasInsufficientTokens, remainingCredits } = useCredit();
   const { user } = useAuth();
@@ -37,6 +45,23 @@ export default function EastChristHomePage() {
   const [allowedUploaders, setAllowedUploaders] = useState<string[]>([]);
   const hasUploadPermission = !!user?.user_id && allowedUploaders.includes(user.user_id);
 
+  const [selectedMode, setSelectedMode] = useState<GuideMode>(null);
+  const [sermonContent, setSermonContent] = useState<string | null>(null);
+  const [navLoading, setNavLoading] = useState(false);
+  const [navFileName, setNavFileName] = useState<string>('');
+  const [navUploadTime, setNavUploadTime] = useState<string>('');
+  const [pdfLoading, setPdfLoading] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const {
+    messages, currentThreadId, setCurrentThreadId, sendMessage,
+    isLoading: chatLoading, error: chatError, setError: setChatError,
+    setMessages, loadChatHistory,
+  } = useChat();
+  const shouldLoadHistory = useRef(false);
+
   useEffect(() => {
     fetch('/api/admin/sunday-guide-units')
       .then((r) => r.json())
@@ -48,6 +73,33 @@ export default function EastChristHomePage() {
 
   useEffect(() => { setIsUploadDisabled(remainingCredits <= 0); }, [remainingCredits, hasInsufficientTokens]);
   useEffect(() => { localStorage.setItem('currentUnitId', 'eastChristHome'); }, []);
+
+  useEffect(() => {
+    if (chatError) {
+      const t = setTimeout(() => setChatError(''), 8000);
+      return () => clearTimeout(t);
+    }
+  }, [chatError, setChatError]);
+
+  useEffect(() => {
+    if (currentThreadId && user && shouldLoadHistory.current) {
+      shouldLoadHistory.current = false;
+      loadChatHistory(user.user_id);
+    }
+  }, [currentThreadId]);
+
+  useEffect(() => {
+    if (allFiles.length === 0) return;
+    const storedId = typeof window !== 'undefined' ? localStorage.getItem('selectedFileId') : null;
+    const storedName = typeof window !== 'undefined' ? localStorage.getItem('selectedFileName') : null;
+    const target = (storedId ? allFiles.find(f => f.fileId === storedId) : null) || allFiles[0];
+    if (!target) return;
+    if (!selectedFileId) setSelectedFileId(target.fileId);
+    const displayName = (!target.fileName.toLowerCase().endsWith('.pdf') && target.sermonTitle)
+      ? target.sermonTitle : target.fileName;
+    setNavFileName(storedName || displayName);
+    setNavUploadTime(target.uploadDate);
+  }, [allFiles]);
 
   const fetchAllFileRecords = async () => {
     try {
@@ -89,7 +141,13 @@ export default function EastChristHomePage() {
         alert('刪除失敗: ' + (data.error || res.status));
       } else {
         await fetchAllFileRecords();
-        if (selectedFileId === fileId) setSelectedFileId(null);
+        if (selectedFileId === fileId) {
+          setSelectedFileId(null);
+          setNavFileName('');
+          setNavUploadTime('');
+          setSermonContent(null);
+          setSelectedMode(null);
+        }
       }
     } catch (e: any) {
       alert('刪除時發生錯誤: ' + (e.message || '未知錯誤'));
@@ -112,6 +170,7 @@ export default function EastChristHomePage() {
       const data = await res.json();
       if (res.ok && data.success) {
         setAllFiles(prev => prev.map(f => f.fileId === fileId ? { ...f, sermonTitle: data.sermonTitle } : f));
+        if (selectedFileId === fileId) setNavFileName(data.sermonTitle || newTitle.trim());
       } else {
         alert('更新失敗: ' + (data.error || res.status));
       }
@@ -130,174 +189,181 @@ export default function EastChristHomePage() {
     await refreshUsage();
   };
 
-  const handleSelectFile = (fileId: string, fileName: string) => {
+  const handleSelectFile = (fileId: string, fileName?: string) => {
     setSelectedFileId(fileId);
+    setSermonContent(null);
+    setSelectedMode(null);
+    const file = recentFiles.find(f => f.fileId === fileId);
+    const displayName = fileName || (file
+      ? ((!file.fileName.toLowerCase().endsWith('.pdf') && file.sermonTitle) ? file.sermonTitle : file.fileName)
+      : '');
+    setNavFileName(displayName);
+    setNavUploadTime(file?.uploadDate || '');
     try {
       localStorage.setItem('selectedFileId', fileId);
-      localStorage.setItem('selectedFileName', fileName);
+      localStorage.setItem('selectedFileName', displayName);
       localStorage.setItem('currentUnitId', 'eastChristHome');
       const channel = new BroadcastChannel('file-selection');
-      channel.postMessage({
-        type: 'FILE_SELECTED',
-        assistantId: eastUnit.assistantId,
-        fileId,
-        fileName,
-        ts: Date.now(),
-      });
+      channel.postMessage({ type: 'FILE_SELECTED', assistantId: eastUnit.assistantId, fileId, fileName: displayName, ts: Date.now() });
       channel.close();
     } catch (err) {
       console.warn('broadcast file selection failed', err);
     }
   };
 
+  const handleCreateNewThread = () => { setCurrentThreadId(null); setMessages([]); };
+  const handleSelectThread = (threadId: string) => {
+    if (threadId === currentThreadId) return;
+    shouldLoadHistory.current = true;
+    setChatError('');
+    setMessages([]);
+    setCurrentThreadId(threadId);
+    setSidebarOpen(false);
+  };
+  const handleSendMessage = async (message: string) => {
+    await sendMessage(message);
+    window.dispatchEvent(new CustomEvent('refreshConversations'));
+  };
+  const handleModeSelect = async (mode: GuideMode) => {
+    if (!selectedFileId) return;
+    setSelectedMode(mode);
+    setNavLoading(true);
+    try {
+      const userId = user?.user_id || '';
+      const apiUrl = `/api/sunday-guide/content/${eastUnit.assistantId}?type=${mode}&userId=${encodeURIComponent(userId)}&fileId=${encodeURIComponent(selectedFileId)}`;
+      const response = await fetch(apiUrl);
+      if (response.status === 202) { const data = await response.json().catch(() => ({})); setSelectedMode(null); alert(data.error || '內容正在生成中，請稍候再試'); return; }
+      if (!response.ok) { const errData = await response.json().catch(() => ({ error: '未知錯誤' })); throw new Error(`获取内容失败: ${response.status} - ${errData.error || response.statusText}`); }
+      const data = await response.json();
+      setSermonContent(data.content);
+      await refreshUsage();
+    } catch (e) { console.error(e); alert(e instanceof Error ? e.message : '請稍後重試'); }
+    finally { setNavLoading(false); }
+  };
+  const handleDownloadPDF = () => {
+    setPdfError(null); setPdfLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set('assistantId', eastUnit.assistantId);
+      params.set('userId', user?.user_id || '');
+      params.set('includeAll', 'true');
+      window.open(`/api/sunday-guide/download-pdf?${params.toString()}`, '_blank');
+      setTimeout(() => setPdfLoading(false), 1200);
+    } catch (err) { setPdfError(err instanceof Error ? err.message : '下載失敗'); setPdfLoading(false); }
+  };
+  const renderNavContent = () => {
+    if (navLoading) return <div className={styles.loading}>加载中，请稍候...</div>;
+    if (!sermonContent) return null;
+    const titles: Record<string, string> = { summary: '讲道总结', devotional: '每日灵修', bible: '查经指引' };
+    return (
+      <div className={styles.contentBox}>
+        <div className={styles.contentHeader}>
+          <h2>{titles[selectedMode!]}</h2>
+          <button className={styles.downloadButton} onClick={handleDownloadPDF} disabled={pdfLoading}>{pdfLoading ? '生成中...' : '下载完整版'}</button>
+        </div>
+        {pdfError && <div className={styles.errorMessage}>{pdfError}</div>}
+        <div className={styles.markdownContent} ref={contentRef}><ReactMarkdown>{sermonContent}</ReactMarkdown></div>
+      </div>
+    );
+  };
+
   return (
-    <WithChat chatType="sunday-guide">
-      <div className={styles.container}>
-        <UserIdDisplay />
-
-        {/* =============== 1. Upload Section =============== */}
-        {hasUploadPermission && (
-          <section className={styles.uploadHero}>
-            <h2 className={styles.uploadHeroTitle}>上传讲章</h2>
-            <p className={styles.uploadHeroDesc}>
-              上传主日讲章文件，系统将自动生成<strong>信息总结</strong>、<strong>每日灵修</strong>与<strong>查经指引</strong>。
-              <br />
-              支持格式：<strong>PDF / 文件</strong>、<strong>YouTube 链接</strong>、<strong>音频文件</strong>
-            </p>
-
-            {isUploadDisabled && (
-              <span className={styles.creditWarningInline}>额度不足，无法上传</span>
-            )}
-            {!isUploadDisabled && remainingCredits > 0 && remainingCredits < 20 && (
-              <span className={styles.creditWarningInline} style={{ background: '#fef3c7', color: '#92400e' }}>
-                余额较低 ({remainingCredits})
-              </span>
-            )}
-
-            <div className={styles.uploadArea}>
-              <SermonInputTabs
-                onFileProcessed={handleFileProcessed}
-                setIsProcessing={setIsProcessing}
-                setUploadProgress={setUploadProgress}
-                setUploadTime={setUploadTime}
-                disabled={isUploadDisabled}
-                assistantId={eastUnit.assistantId}
-                vectorStoreId={eastUnit.vectorStoreId}
-                unitId="eastChristHome"
-              />
-            </div>
-
-            {isProcessing && (
-              <div className={styles.processingAlert}>
-                <p>处理中，约需 3-5 分钟，请勿关闭页面...</p>
-              </div>
-            )}
-            {uploadTime && (
-              <span className={styles.uploadTimeBadge}>✓ 完成于 {uploadTime}</span>
-            )}
-          </section>
-        )}
-
-        {/* =============== 2. Sidebar + Placeholder =============== */}
-        <div className={styles.mainLayout}>
-          <aside className={styles.docsSection}>
-            <h4 className={styles.docsSectionTitle}>
-              📚 文档列表
-              <span className={styles.docsSectionHint}>— 选择一份讲章</span>
-            </h4>
-
-            {recentFiles.length === 0 ? (
-              <div className={styles.noDocs}>暂无文档</div>
-            ) : (
-              <>
-                <ul className={styles.docsListScrollable}>
-                  {recentFiles.map((file, idx) => (
-                    <li
-                      key={file.fileId || idx}
-                      className={`${styles.docItem} ${selectedFileId === file.fileId ? styles.docItemSelected : ''}`}
-                      onClick={() => handleSelectFile(file.fileId, file.fileName.toLowerCase().endsWith('.pdf') ? file.fileName : (file.sermonTitle || file.fileName))}
-                      title="点击选择此文档"
-                    >
-                      {(user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id))) ? (
-                        <button
-                          onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }}
-                          disabled={deletingId === file.fileId}
-                          className={styles.deleteButton}
-                          title="删除此文档"
-                        >
-                          {deletingId === file.fileId ? '...' : '×'}
-                        </button>
-                      ) : (
-                        <span className={styles.deleteButtonPlaceholder} />
-                      )}
-                      <span className={styles.docIndex}>{(currentPage - 1) * filesPerPage + idx + 1}.</span>
-                      {editingFileId === file.fileId ? (
-                        <input
-                          className={styles.docTitleInput}
-                          value={editingTitle}
-                          autoFocus
-                          onChange={e => setEditingTitle(e.target.value)}
+    <div className={styles.container}>
+      <UserIdDisplay />
+      {hasUploadPermission && (
+        <section className={styles.uploadHero}>
+          <h2 className={styles.uploadHeroTitle}>上传讲章</h2>
+          <p className={styles.uploadHeroDesc}>上传主日讲章文件，系统将自动生成<strong>信息总结</strong>、<strong>每日灵修</strong>与<strong>查经指引</strong>。<br />支持格式：<strong>PDF / 文件</strong>、<strong>YouTube 链接</strong>、<strong>音频文件</strong></p>
+          {isUploadDisabled && <span className={styles.creditWarningInline}>额度不足，无法上传</span>}
+          {!isUploadDisabled && remainingCredits > 0 && remainingCredits < 20 && (<span className={styles.creditWarningInline} style={{ background: '#fef3c7', color: '#92400e' }}>余额较低 ({remainingCredits})</span>)}
+          <div className={styles.uploadArea}>
+            <SermonInputTabs onFileProcessed={handleFileProcessed} setIsProcessing={setIsProcessing} setUploadProgress={setUploadProgress} setUploadTime={setUploadTime} disabled={isUploadDisabled} assistantId={eastUnit.assistantId} vectorStoreId={eastUnit.vectorStoreId} unitId="eastChristHome" />
+          </div>
+          {isProcessing && <div className={styles.processingAlert}><p>处理中，约需 3-5 分钟，请勿关闭页面...</p></div>}
+          {uploadTime && <span className={styles.uploadTimeBadge}>✓ 完成于 {uploadTime}</span>}
+        </section>
+      )}
+      <div className={styles.mainLayout}>
+        <aside className={styles.docsSection}>
+          <h4 className={styles.docsSectionTitle}>📚 文档列表<span className={styles.docsSectionHint}>— 选择一份讲章</span></h4>
+          {recentFiles.length === 0 ? <div className={styles.noDocs}>暂无文档</div> : (
+            <>
+              <ul className={styles.docsListScrollable}>
+                {recentFiles.map((file, idx) => (
+                  <li key={file.fileId || idx} className={`${styles.docItem} ${selectedFileId === file.fileId ? styles.docItemSelected : ''}`}
+                    onClick={() => handleSelectFile(file.fileId)} title="点击选择此文档">
+                    {(user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id)))
+                      ? <button onClick={(e) => { e.stopPropagation(); handleDelete(file.fileId, file.uploaderId); }} disabled={deletingId === file.fileId} className={styles.deleteButton} title="删除此文档">{deletingId === file.fileId ? '...' : '×'}</button>
+                      : <span className={styles.deleteButtonPlaceholder} />}
+                    <span className={styles.docIndex}>{(currentPage - 1) * filesPerPage + idx + 1}.</span>
+                    {editingFileId === file.fileId
+                      ? <input className={styles.docTitleInput} value={editingTitle} autoFocus onChange={e => setEditingTitle(e.target.value)}
                           onBlur={() => handleRenameTitle(file.fileId, editingTitle)}
-                          onKeyDown={e => {
-                            if (e.key === 'Enter') handleRenameTitle(file.fileId, editingTitle);
-                            if (e.key === 'Escape') setEditingFileId(null);
-                          }}
-                          onClick={e => e.stopPropagation()}
-                        />
-                      ) : (
-                        <>
-                          <span className={styles.docFileName}>{file.fileName.toLowerCase().endsWith('.pdf') ? file.fileName : (file.sermonTitle || file.fileName)}</span>
+                          onKeyDown={e => { if (e.key === 'Enter') handleRenameTitle(file.fileId, editingTitle); if (e.key === 'Escape') setEditingFileId(null); }}
+                          onClick={e => e.stopPropagation()} />
+                      : <><span className={styles.docFileName}>{file.fileName.toLowerCase().endsWith('.pdf') ? file.fileName : (file.sermonTitle || file.fileName)}</span>
                           {user?.user_id && (user.user_id === file.uploaderId || allowedUploaders.includes(user.user_id)) && (
-                            <button
-                              className={styles.editTitleButton}
-                              title="編輯標題"
-                              onClick={e => {
-                                e.stopPropagation();
-                                setEditingTitle(file.sermonTitle || file.fileName);
-                                setEditingFileId(file.fileId);
-                              }}
-                            >✎</button>
-                          )}
-                        </>
-                      )}
-                      <span className={styles.docDate}>{file.uploadDate}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                {allFiles.length > 0 && (
-                  <div className={styles.pagination}>
-                    <button
-                      onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                      disabled={currentPage === 1}
-                      className={styles.paginationButton}
-                    >
-                      ←
-                    </button>
-                    <span className={styles.paginationInfo}>{currentPage} / {totalPages}</span>
-                    <button
-                      onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                      disabled={currentPage === totalPages}
-                      className={styles.paginationButton}
-                    >
-                      →
-                    </button>
+                            <button className={styles.editTitleButton} title="編輯標題" onClick={e => { e.stopPropagation(); setEditingTitle(file.sermonTitle || file.fileName); setEditingFileId(file.fileId); }}>✎</button>
+                          )}</>
+                    }
+                    <span className={styles.docDate}>{file.uploadDate}</span>
+                  </li>
+                ))}
+              </ul>
+              {allFiles.length > 0 && (
+                <div className={styles.pagination}>
+                  <button onClick={() => setCurrentPage((p) => Math.max(1, p - 1))} disabled={currentPage === 1} className={styles.paginationButton}>←</button>
+                  <span className={styles.paginationInfo}>{currentPage} / {totalPages}</span>
+                  <button onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages} className={styles.paginationButton}>→</button>
+                </div>
+              )}
+            </>
+          )}
+        </aside>
+        <div className={styles.navigatorPanel}>
+          <h2 style={{ textAlign: 'center', fontSize: '1.1rem', fontWeight: 700, color: '#1e293b', margin: '0 0 0.5rem' }}>主日信息导航</h2>
+          {navFileName && <div style={{ fontSize: '13px', color: '#0070f3', marginBottom: 8, textAlign: 'center' }}>当前文件: {navFileName}{navUploadTime && ` (上传时间: ${navUploadTime})`}</div>}
+          <div className={styles.buttonGroup}>
+            <button className={`${styles.modeButton} ${selectedMode === 'summary' ? styles.active : ''}`} onClick={() => handleModeSelect('summary')} disabled={!selectedFileId}>信息总结</button>
+            <button className={`${styles.modeButton} ${selectedMode === 'devotional' ? styles.active : ''}`} onClick={() => handleModeSelect('devotional')} disabled={!selectedFileId}>每日灵修</button>
+            <button className={`${styles.modeButton} ${selectedMode === 'bible' ? styles.active : ''}`} onClick={() => handleModeSelect('bible')} disabled={!selectedFileId}>查经指引</button>
+          </div>
+          {allFiles.length === 0 && <div style={{ fontSize: '14px', color: '#ff6b6b', textAlign: 'center', padding: '12px', background: '#fff5f5', borderRadius: '8px', border: '1px solid #ffebee' }}>目前尚无可用文件</div>}
+          <div className={styles.contentWrapper}>
+            {sermonContent ? (
+              <>
+                <div className={`${styles.contentArea} ${styles.hasContent}`}>{renderNavContent()}</div>
+                <div className={styles.chatSection}>
+                  <div className={chatStyles.chatWrapper}>
+                    <div className={`${chatStyles.sidebar}${sidebarOpen ? ' ' + chatStyles.sidebarOpen : ''}`}>
+                      <button className={chatStyles.sidebarToggle} onClick={() => setSidebarOpen(v => !v)}>
+                        <span>📋 對話記錄</span><span>{sidebarOpen ? '▲' : '▼'}</span>
+                      </button>
+                      <ConversationList userId={user!.user_id} type="east-christ-home" currentThreadId={currentThreadId}
+                        onSelectThread={handleSelectThread} isCreating={false} onCreateNewThread={handleCreateNewThread} sidebarMode={true} />
+                    </div>
+                    <div className={chatStyles.main}>
+                      <MessageList messages={messages} isLoading={chatLoading} />
+                      {chatError && <div style={{ color: '#f55', padding: '6px 16px', background: '#3a0000' }}>{chatError}</div>}
+                      <ChatInput onSend={handleSendMessage} isLoading={chatLoading} />
+                    </div>
                   </div>
-                )}
+                </div>
               </>
+            ) : (
+              <div style={{ textAlign: 'center', width: '100%', padding: '2rem 0', color: '#94a3b8' }}><p>请先选择要查看的内容类型</p></div>
             )}
-          </aside>
-
-          <div className={styles.guidePlaceholder}>
-            <div className={styles.guidePlaceholderIcon}>👈</div>
-            <p className={styles.guidePlaceholderText}>
-              选择讲章后可前往<br />
-              <a href="/east-christ-home/navigator" style={{ color: '#0070f3', textDecoration: 'underline' }}>東基家信息導覽</a><br />
-              查看信息总结、灵修与查经
-            </p>
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+export default function EastChristHomePage() {
+  return (
+    <WithChat chatType="east-christ-home">
+      <EastChristHomeContent />
     </WithChat>
   );
 }

--- a/app/sunday-guide-v2/SundayGuide.module.css
+++ b/app/sunday-guide-v2/SundayGuide.module.css
@@ -369,6 +369,20 @@
   line-height: 1.6;
 }
 
+/* ==================== Navigator Panel (integrated right column) ==================== */
+.navigatorPanel {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.06);
+}
+
 @keyframes fadeSlideIn {
   from { opacity: 0; transform: translateY(12px); }
   to   { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
…button

- Merge /navigator into main church pages (agape, cfsc, east-christ-home, chinese-pastor-network) as inline right-panel
- Add .navigatorPanel CSS class with card styling; hidden on mobile (≤900px)
- Replace chat send button text with circular SVG arrow icon (all assistants)