### PR TITLE
Add "AI" family assistant unit and unify chat toggle button across all assistant pages

### DIFF
--- a/app/agape-church/navigator/chat.module.css
+++ b/app/agape-church/navigator/chat.module.css
@@ -1,7 +1,6 @@
 /* 遠志明耶穌頌 — Floating Chat Widget */
 
 /* ── CSS variables ── */
-.floatingBubble,
 .floatingPanel {
   --chat-bg: #ffffff;
   --chat-sidebar-bg: #f5f5f5;
@@ -18,41 +17,6 @@
   --chat-new-btn-color: #ffffff;
   --chat-send-btn-bg: #1a1a1a;
   --chat-send-btn-hover: #333333;
-}
-
-/* ── Floating bubble button ── */
-.floatingBubble {
-  position: fixed;
-  bottom: 28px;
-  right: 28px;
-  z-index: 1100;
-  width: 67px;
-  height: 67px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #f87171 0%, #b91c1c 100%);
-  box-shadow: 0 4px 20px rgba(185, 28, 28, 0.45), 0 2px 8px rgba(0,0,0,0.18);
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  user-select: none;
-}
-
-.floatingBubble:hover {
-  transform: scale(1.08);
-  box-shadow: 0 6px 28px rgba(185, 28, 28, 0.55), 0 3px 12px rgba(0,0,0,0.22);
-}
-
-.floatingBubble:active {
-  transform: scale(0.96);
-}
-
-.bubbleIcon {
-  width: 33px;
-  height: 33px;
-  display: block;
 }
 
 /* ── Floating chat panel ── */
@@ -179,18 +143,6 @@
 
 /* ── Mobile: full-width bottom sheet ── */
 @media (max-width: 768px) {
-  .floatingBubble {
-    bottom: 20px;
-    right: 20px;
-    width: 60px;
-    height: 60px;
-  }
-
-  .bubbleIcon {
-    width: 30px;
-    height: 30px;
-  }
-
   .floatingPanel {
     bottom: 0;
     right: 0;

--- a/app/agape-church/page.tsx
+++ b/app/agape-church/page.tsx
@@ -10,6 +10,7 @@ import { useChat } from '../contexts/ChatContext';
 import ConversationList from '../components/ConversationList';
 import MessageList from '../components/Chat/MessageList';
 import ChatInput from '../components/Chat/ChatInput';
+import AIFloatingBubble from '../components/Chat/AIFloatingBubble';
 import ReactMarkdown from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
 import chatStyles from './navigator/chat.module.css';
@@ -534,14 +535,7 @@ function AgapeChurchContent() {
               </div>
             </div>
           </div>
-          <button className={chatStyles.floatingBubble} onClick={() => { setChatOpen(v => !v); setSidebarOpen(false); }} title="AI 對話助手">
-            <svg className={chatStyles.bubbleIcon} viewBox="0 0 24 24" fill="none">
-              <path d="M6 4H18C19.6569 4 21 5.34315 21 7V14C21 15.6569 19.6569 17 18 17H10.5L6.5 21V17H6C4.34315 17 3 15.6569 3 14V7C3 5.34315 4.34315 4 6 4Z" stroke="#ffffff" strokeWidth="1.6" strokeLinejoin="round" />
-              <line x1="7.5" y1="8.4" x2="16.5" y2="8.4" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="11" x2="16.5" y2="11" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="13.6" x2="13" y2="13.6" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
-          </button>
+          <AIFloatingBubble open={chatOpen} onToggle={() => { setChatOpen(v => !v); setSidebarOpen(false); }} />
         </>
       )}
     </div>

--- a/app/cfsc-church/navigator/chat.module.css
+++ b/app/cfsc-church/navigator/chat.module.css
@@ -1,7 +1,6 @@
 /* 遠志明耶穌頌 — Floating Chat Widget */
 
 /* ── CSS variables ── */
-.floatingBubble,
 .floatingPanel {
   --chat-bg: #ffffff;
   --chat-sidebar-bg: #f5f5f5;
@@ -18,41 +17,6 @@
   --chat-new-btn-color: #ffffff;
   --chat-send-btn-bg: #1a1a1a;
   --chat-send-btn-hover: #333333;
-}
-
-/* ── Floating bubble button ── */
-.floatingBubble {
-  position: fixed;
-  bottom: 28px;
-  right: 28px;
-  z-index: 1100;
-  width: 67px;
-  height: 67px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #f87171 0%, #b91c1c 100%);
-  box-shadow: 0 4px 20px rgba(185, 28, 28, 0.45), 0 2px 8px rgba(0,0,0,0.18);
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  user-select: none;
-}
-
-.floatingBubble:hover {
-  transform: scale(1.08);
-  box-shadow: 0 6px 28px rgba(185, 28, 28, 0.55), 0 3px 12px rgba(0,0,0,0.22);
-}
-
-.floatingBubble:active {
-  transform: scale(0.96);
-}
-
-.bubbleIcon {
-  width: 33px;
-  height: 33px;
-  display: block;
 }
 
 /* ── Floating chat panel ── */
@@ -179,18 +143,6 @@
 
 /* ── Mobile: full-width bottom sheet ── */
 @media (max-width: 768px) {
-  .floatingBubble {
-    bottom: 20px;
-    right: 20px;
-    width: 60px;
-    height: 60px;
-  }
-
-  .bubbleIcon {
-    width: 30px;
-    height: 30px;
-  }
-
   .floatingPanel {
     bottom: 0;
     right: 0;

--- a/app/cfsc-church/page.tsx
+++ b/app/cfsc-church/page.tsx
@@ -10,6 +10,7 @@ import { useChat } from '../contexts/ChatContext';
 import ConversationList from '../components/ConversationList';
 import MessageList from '../components/Chat/MessageList';
 import ChatInput from '../components/Chat/ChatInput';
+import AIFloatingBubble from '../components/Chat/AIFloatingBubble';
 import ReactMarkdown from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
 import chatStyles from './navigator/chat.module.css';
@@ -444,14 +445,7 @@ function CfscChurchContent() {
               </div>
             </div>
           </div>
-          <button className={chatStyles.floatingBubble} onClick={() => { setChatOpen(v => !v); setSidebarOpen(false); }} title="AI 對話助手">
-            <svg className={chatStyles.bubbleIcon} viewBox="0 0 24 24" fill="none">
-              <path d="M6 4H18C19.6569 4 21 5.34315 21 7V14C21 15.6569 19.6569 17 18 17H10.5L6.5 21V17H6C4.34315 17 3 15.6569 3 14V7C3 5.34315 4.34315 4 6 4Z" stroke="#ffffff" strokeWidth="1.6" strokeLinejoin="round" />
-              <line x1="7.5" y1="8.4" x2="16.5" y2="8.4" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="11" x2="16.5" y2="11" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="13.6" x2="13" y2="13.6" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
-          </button>
+          <AIFloatingBubble open={chatOpen} onToggle={() => { setChatOpen(v => !v); setSidebarOpen(false); }} />
         </>
       )}
     </div>

--- a/app/child-mental/page.module.css
+++ b/app/child-mental/page.module.css
@@ -1,17 +1,6 @@
-/* Child Mental — Always-visible chat panel */
+/* Child Mental — Floating Chat Widget */
 
-.container {
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
-  height: 100dvh;
-  width: 100%;
-  background: #f1f5f9;
-  padding: 20px;
-  box-sizing: border-box;
-}
-
-.panel {
+.floatingPanel {
   --chat-bg: #ffffff;
   --chat-sidebar-bg: #f5f5f5;
   --chat-input-bg: #eeeeee;
@@ -27,45 +16,63 @@
   --chat-new-btn-color: #ffffff;
   --chat-send-btn-bg: #1a1a1a;
   --chat-send-btn-hover: #333333;
+  position: fixed;
+  bottom: 100px;
+  right: 28px;
+  z-index: 1099;
+  width: 712px;
+  height: 520px;
+  border-radius: 16px;
+  background: var(--chat-bg);
+  box-shadow: 0 8px 40px rgba(15, 23, 42, 0.18), 0 2px 12px rgba(0,0,0,0.1);
+  border: 1px solid #e2e8f0;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: 900px;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 8px 40px rgba(15, 23, 42, 0.12), 0 2px 12px rgba(0,0,0,0.08);
-  border: 1px solid #e2e8f0;
   overflow: hidden;
+  opacity: 0;
+  transform: translateY(16px) scale(0.97);
+  pointer-events: none;
+  transition: opacity 0.22s ease, transform 0.22s ease;
+}
+
+.floatingPanel.panelOpen {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
 }
 
 .panelHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 20px;
+  padding: 12px 16px;
   background: linear-gradient(135deg, #3b82f6 0%, #6366f1 100%);
   flex-shrink: 0;
 }
 
 .panelTitle {
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: #ffffff;
+  margin: 0;
 }
 
-.newChatBtn {
+.panelClose {
   background: rgba(255,255,255,0.2);
-  border: 1px solid rgba(255,255,255,0.3);
+  border: none;
   color: #ffffff;
-  padding: 4px 12px;
-  border-radius: 8px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
   cursor: pointer;
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background 0.15s;
 }
 
-.newChatBtn:hover {
+.panelClose:hover {
   background: rgba(255,255,255,0.35);
 }
 
@@ -132,14 +139,21 @@
 }
 
 @media (max-width: 768px) {
-  .container {
-    padding: 0;
-    background: #ffffff;
+  .floatingPanel {
+    bottom: 0;
+    right: 0;
+    left: 0;
+    width: 100%;
+    height: 72vh;
+    border-radius: 20px 20px 0 0;
+    transform: translateY(24px) scale(1);
   }
 
-  .panel {
-    border-radius: 0;
-    box-shadow: none;
-    border: none;
+  .floatingPanel.panelOpen {
+    transform: translateY(0) scale(1);
+  }
+
+  .sidebar.sidebarOpen {
+    max-height: calc(72vh - 44px - 70px);
   }
 }

--- a/app/child-mental/page.tsx
+++ b/app/child-mental/page.tsx
@@ -7,6 +7,7 @@ import { useChat } from '@/app/contexts/ChatContext';
 import ConversationList from '@/app/components/ConversationList';
 import MessageList from '@/app/components/Chat/MessageList';
 import ChatInput from '@/app/components/Chat/ChatInput';
+import AIFloatingBubble from '@/app/components/Chat/AIFloatingBubble';
 import styles from './page.module.css';
 
 function ChildMentalContent() {
@@ -23,6 +24,7 @@ function ChildMentalContent() {
     setMessages,
   } = useChat();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
   const shouldLoadHistory = useRef(false);
 
   useEffect(() => {
@@ -54,9 +56,11 @@ function ChildMentalContent() {
   if (!user) return null;
 
   return (
-    <div className={styles.container}>
-      <div className={styles.panel}>
+    <>
+      <div className={`${styles.floatingPanel}${chatOpen ? ' ' + styles.panelOpen : ''}`}>
         <div className={styles.panelHeader}>
+          <span className={styles.panelTitle}>🧒 兒童心理 AI 助手</span>
+          <button className={styles.panelClose} onClick={() => setChatOpen(false)}>✕</button>
         </div>
         <div className={styles.chatWrapper}>
           <div className={`${styles.sidebar}${sidebarOpen ? ' ' + styles.sidebarOpen : ''}`}>
@@ -80,7 +84,8 @@ function ChildMentalContent() {
           </div>
         </div>
       </div>
-    </div>
+      <AIFloatingBubble open={chatOpen} onToggle={() => { setChatOpen(v => !v); setSidebarOpen(false); }} />
+    </>
   );
 }
 

--- a/app/chinese-pastor-network/navigator/chat.module.css
+++ b/app/chinese-pastor-network/navigator/chat.module.css
@@ -1,7 +1,6 @@
 /* 遠志明耶穌頌 — Floating Chat Widget */
 
 /* ── CSS variables ── */
-.floatingBubble,
 .floatingPanel {
   --chat-bg: #ffffff;
   --chat-sidebar-bg: #f5f5f5;
@@ -18,41 +17,6 @@
   --chat-new-btn-color: #ffffff;
   --chat-send-btn-bg: #1a1a1a;
   --chat-send-btn-hover: #333333;
-}
-
-/* ── Floating bubble button ── */
-.floatingBubble {
-  position: fixed;
-  bottom: 28px;
-  right: 28px;
-  z-index: 1100;
-  width: 67px;
-  height: 67px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #f87171 0%, #b91c1c 100%);
-  box-shadow: 0 4px 20px rgba(185, 28, 28, 0.45), 0 2px 8px rgba(0,0,0,0.18);
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  user-select: none;
-}
-
-.floatingBubble:hover {
-  transform: scale(1.08);
-  box-shadow: 0 6px 28px rgba(185, 28, 28, 0.55), 0 3px 12px rgba(0,0,0,0.22);
-}
-
-.floatingBubble:active {
-  transform: scale(0.96);
-}
-
-.bubbleIcon {
-  width: 33px;
-  height: 33px;
-  display: block;
 }
 
 /* ── Floating chat panel ── */
@@ -179,18 +143,6 @@
 
 /* ── Mobile: full-width bottom sheet ── */
 @media (max-width: 768px) {
-  .floatingBubble {
-    bottom: 20px;
-    right: 20px;
-    width: 60px;
-    height: 60px;
-  }
-
-  .bubbleIcon {
-    width: 30px;
-    height: 30px;
-  }
-
   .floatingPanel {
     bottom: 0;
     right: 0;

--- a/app/chinese-pastor-network/page.tsx
+++ b/app/chinese-pastor-network/page.tsx
@@ -10,6 +10,7 @@ import { useChat } from '../contexts/ChatContext';
 import ConversationList from '../components/ConversationList';
 import MessageList from '../components/Chat/MessageList';
 import ChatInput from '../components/Chat/ChatInput';
+import AIFloatingBubble from '../components/Chat/AIFloatingBubble';
 import ReactMarkdown from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
 import chatStyles from './navigator/chat.module.css';
@@ -333,14 +334,7 @@ function ChinesePastorNetworkContent() {
               </div>
             </div>
           </div>
-          <button className={chatStyles.floatingBubble} onClick={() => { setChatOpen(v => !v); setSidebarOpen(false); }} title="AI 對話助手">
-            <svg className={chatStyles.bubbleIcon} viewBox="0 0 24 24" fill="none">
-              <path d="M6 4H18C19.6569 4 21 5.34315 21 7V14C21 15.6569 19.6569 17 18 17H10.5L6.5 21V17H6C4.34315 17 3 15.6569 3 14V7C3 5.34315 4.34315 4 6 4Z" stroke="#ffffff" strokeWidth="1.6" strokeLinejoin="round" />
-              <line x1="7.5" y1="8.4" x2="16.5" y2="8.4" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="11" x2="16.5" y2="11" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="13.6" x2="13" y2="13.6" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
-          </button>
+          <AIFloatingBubble open={chatOpen} onToggle={() => { setChatOpen(v => !v); setSidebarOpen(false); }} />
         </>
       )}
     </div>

--- a/app/components/Chat/AIFloatingBubble.module.css
+++ b/app/components/Chat/AIFloatingBubble.module.css
@@ -1,0 +1,37 @@
+/* Shared AI chat toggle button — same size/shape on mobile and desktop */
+
+.bubble {
+  position: fixed;
+  bottom: 28px;
+  right: 28px;
+  z-index: 1100;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: #2563eb;
+  box-shadow: 0 4px 20px rgba(37, 99, 235, 0.45), 0 2px 8px rgba(0, 0, 0, 0.18);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  user-select: none;
+}
+
+.bubble:hover {
+  transform: scale(1.08);
+  box-shadow: 0 6px 28px rgba(37, 99, 235, 0.55), 0 3px 12px rgba(0, 0, 0, 0.22);
+}
+
+.bubble:active {
+  transform: scale(0.96);
+}
+
+.bubbleLabel {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #ffffff;
+  letter-spacing: 0.02em;
+  line-height: 1;
+}

--- a/app/components/Chat/AIFloatingBubble.tsx
+++ b/app/components/Chat/AIFloatingBubble.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import styles from './AIFloatingBubble.module.css';
+
+interface AIFloatingBubbleProps {
+  open: boolean;
+  onToggle: () => void;
+  title?: string;
+}
+
+export default function AIFloatingBubble({ open, onToggle, title = 'AI 對話助手' }: AIFloatingBubbleProps) {
+  return (
+    <button
+      className={`${styles.bubble}${open ? ' ' + styles.bubbleOpen : ''}`}
+      onClick={onToggle}
+      title={title}
+      aria-label={title}
+    >
+      <span className={styles.bubbleLabel}>AI</span>
+    </button>
+  );
+}

--- a/app/east-christ-home/navigator/chat.module.css
+++ b/app/east-christ-home/navigator/chat.module.css
@@ -1,7 +1,6 @@
 /* 遠志明耶穌頌 — Floating Chat Widget */
 
 /* ── CSS variables ── */
-.floatingBubble,
 .floatingPanel {
   --chat-bg: #ffffff;
   --chat-sidebar-bg: #f5f5f5;
@@ -18,41 +17,6 @@
   --chat-new-btn-color: #ffffff;
   --chat-send-btn-bg: #1a1a1a;
   --chat-send-btn-hover: #333333;
-}
-
-/* ── Floating bubble button ── */
-.floatingBubble {
-  position: fixed;
-  bottom: 28px;
-  right: 28px;
-  z-index: 1100;
-  width: 67px;
-  height: 67px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #f87171 0%, #b91c1c 100%);
-  box-shadow: 0 4px 20px rgba(185, 28, 28, 0.45), 0 2px 8px rgba(0,0,0,0.18);
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  user-select: none;
-}
-
-.floatingBubble:hover {
-  transform: scale(1.08);
-  box-shadow: 0 6px 28px rgba(185, 28, 28, 0.55), 0 3px 12px rgba(0,0,0,0.22);
-}
-
-.floatingBubble:active {
-  transform: scale(0.96);
-}
-
-.bubbleIcon {
-  width: 33px;
-  height: 33px;
-  display: block;
 }
 
 /* ── Floating chat panel ── */
@@ -179,18 +143,6 @@
 
 /* ── Mobile: full-width bottom sheet ── */
 @media (max-width: 768px) {
-  .floatingBubble {
-    bottom: 20px;
-    right: 20px;
-    width: 60px;
-    height: 60px;
-  }
-
-  .bubbleIcon {
-    width: 30px;
-    height: 30px;
-  }
-
   .floatingPanel {
     bottom: 0;
     right: 0;

--- a/app/east-christ-home/page.tsx
+++ b/app/east-christ-home/page.tsx
@@ -10,6 +10,7 @@ import { useChat } from '../contexts/ChatContext';
 import ConversationList from '../components/ConversationList';
 import MessageList from '../components/Chat/MessageList';
 import ChatInput from '../components/Chat/ChatInput';
+import AIFloatingBubble from '../components/Chat/AIFloatingBubble';
 import ReactMarkdown from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
 import chatStyles from './navigator/chat.module.css';
@@ -363,14 +364,7 @@ function EastChristHomeContent() {
               </div>
             </div>
           </div>
-          <button className={chatStyles.floatingBubble} onClick={() => { setChatOpen(v => !v); setSidebarOpen(false); }} title="AI 對話助手">
-            <svg className={chatStyles.bubbleIcon} viewBox="0 0 24 24" fill="none">
-              <path d="M6 4H18C19.6569 4 21 5.34315 21 7V14C21 15.6569 19.6569 17 18 17H10.5L6.5 21V17H6C4.34315 17 3 15.6569 3 14V7C3 5.34315 4.34315 4 6 4Z" stroke="#ffffff" strokeWidth="1.6" strokeLinejoin="round" />
-              <line x1="7.5" y1="8.4" x2="16.5" y2="8.4" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="11" x2="16.5" y2="11" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="13.6" x2="13" y2="13.6" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
-          </button>
+          <AIFloatingBubble open={chatOpen} onToggle={() => { setChatOpen(v => !v); setSidebarOpen(false); }} />
         </>
       )}
     </div>

--- a/app/homeschool/Homeschool.module.css
+++ b/app/homeschool/Homeschool.module.css
@@ -1,17 +1,6 @@
-/* Homeschool — Always-visible chat panel */
+/* Homeschool — Floating Chat Widget */
 
-.container {
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
-  height: 100dvh;
-  width: 100%;
-  background: #f1f5f9;
-  padding: 20px;
-  box-sizing: border-box;
-}
-
-.panel {
+.floatingPanel {
   --chat-bg: #ffffff;
   --chat-sidebar-bg: #f5f5f5;
   --chat-input-bg: #eeeeee;
@@ -27,45 +16,63 @@
   --chat-new-btn-color: #ffffff;
   --chat-send-btn-bg: #1a1a1a;
   --chat-send-btn-hover: #333333;
+  position: fixed;
+  bottom: 100px;
+  right: 28px;
+  z-index: 1099;
+  width: 712px;
+  height: 520px;
+  border-radius: 16px;
+  background: var(--chat-bg);
+  box-shadow: 0 8px 40px rgba(15, 23, 42, 0.18), 0 2px 12px rgba(0,0,0,0.1);
+  border: 1px solid #e2e8f0;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: 900px;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 8px 40px rgba(15, 23, 42, 0.12), 0 2px 12px rgba(0,0,0,0.08);
-  border: 1px solid #e2e8f0;
   overflow: hidden;
+  opacity: 0;
+  transform: translateY(16px) scale(0.97);
+  pointer-events: none;
+  transition: opacity 0.22s ease, transform 0.22s ease;
+}
+
+.floatingPanel.panelOpen {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
 }
 
 .panelHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 20px;
+  padding: 12px 16px;
   background: linear-gradient(135deg, #3b82f6 0%, #6366f1 100%);
   flex-shrink: 0;
 }
 
 .panelTitle {
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: #ffffff;
+  margin: 0;
 }
 
-.newChatBtn {
+.panelClose {
   background: rgba(255,255,255,0.2);
-  border: 1px solid rgba(255,255,255,0.3);
+  border: none;
   color: #ffffff;
-  padding: 4px 12px;
-  border-radius: 8px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
   cursor: pointer;
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background 0.15s;
 }
 
-.newChatBtn:hover {
+.panelClose:hover {
   background: rgba(255,255,255,0.35);
 }
 
@@ -132,14 +139,21 @@
 }
 
 @media (max-width: 768px) {
-  .container {
-    padding: 0;
-    background: #ffffff;
+  .floatingPanel {
+    bottom: 0;
+    right: 0;
+    left: 0;
+    width: 100%;
+    height: 72vh;
+    border-radius: 20px 20px 0 0;
+    transform: translateY(24px) scale(1);
   }
 
-  .panel {
-    border-radius: 0;
-    box-shadow: none;
-    border: none;
+  .floatingPanel.panelOpen {
+    transform: translateY(0) scale(1);
+  }
+
+  .sidebar.sidebarOpen {
+    max-height: calc(72vh - 44px - 70px);
   }
 }

--- a/app/homeschool/page.tsx
+++ b/app/homeschool/page.tsx
@@ -7,6 +7,7 @@ import { useChat } from '../contexts/ChatContext';
 import ConversationList from '../components/ConversationList';
 import MessageList from '../components/Chat/MessageList';
 import ChatInput from '../components/Chat/ChatInput';
+import AIFloatingBubble from '../components/Chat/AIFloatingBubble';
 import styles from './Homeschool.module.css';
 
 function HomeschoolContent() {
@@ -23,6 +24,7 @@ function HomeschoolContent() {
     setMessages,
   } = useChat();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
   const shouldLoadHistory = useRef(false);
 
   useEffect(() => {
@@ -54,10 +56,11 @@ function HomeschoolContent() {
   if (!user) return null;
 
   return (
-    <div className={styles.container}>
-      <div className={styles.panel}>
+    <>
+      <div className={`${styles.floatingPanel}${chatOpen ? ' ' + styles.panelOpen : ''}`}>
         <div className={styles.panelHeader}>
           <span className={styles.panelTitle}>🏠 家庭教育 AI 助手</span>
+          <button className={styles.panelClose} onClick={() => setChatOpen(false)}>✕</button>
         </div>
         <div className={styles.chatWrapper}>
           <div className={`${styles.sidebar}${sidebarOpen ? ' ' + styles.sidebarOpen : ''}`}>
@@ -81,7 +84,8 @@ function HomeschoolContent() {
           </div>
         </div>
       </div>
-    </div>
+      <AIFloatingBubble open={chatOpen} onToggle={() => { setChatOpen(v => !v); setSidebarOpen(false); }} />
+    </>
   );
 }
 

--- a/app/spiritual-partner/page.module.css
+++ b/app/spiritual-partner/page.module.css
@@ -1,17 +1,6 @@
-/* Spiritual Partner — Always-visible chat panel */
+/* Spiritual Partner — Floating Chat Widget */
 
-.container {
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
-  height: 100dvh;
-  width: 100%;
-  background: #f1f5f9;
-  padding: 20px;
-  box-sizing: border-box;
-}
-
-.panel {
+.floatingPanel {
   --chat-bg: #ffffff;
   --chat-sidebar-bg: #f5f5f5;
   --chat-input-bg: #eeeeee;
@@ -27,45 +16,63 @@
   --chat-new-btn-color: #ffffff;
   --chat-send-btn-bg: #1a1a1a;
   --chat-send-btn-hover: #333333;
+  position: fixed;
+  bottom: 100px;
+  right: 28px;
+  z-index: 1099;
+  width: 712px;
+  height: 520px;
+  border-radius: 16px;
+  background: var(--chat-bg);
+  box-shadow: 0 8px 40px rgba(15, 23, 42, 0.18), 0 2px 12px rgba(0,0,0,0.1);
+  border: 1px solid #e2e8f0;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: 900px;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: 0 8px 40px rgba(15, 23, 42, 0.12), 0 2px 12px rgba(0,0,0,0.08);
-  border: 1px solid #e2e8f0;
   overflow: hidden;
+  opacity: 0;
+  transform: translateY(16px) scale(0.97);
+  pointer-events: none;
+  transition: opacity 0.22s ease, transform 0.22s ease;
+}
+
+.floatingPanel.panelOpen {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
 }
 
 .panelHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 20px;
+  padding: 12px 16px;
   background: linear-gradient(135deg, #3b82f6 0%, #6366f1 100%);
   flex-shrink: 0;
 }
 
 .panelTitle {
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: #ffffff;
+  margin: 0;
 }
 
-.newChatBtn {
+.panelClose {
   background: rgba(255,255,255,0.2);
-  border: 1px solid rgba(255,255,255,0.3);
+  border: none;
   color: #ffffff;
-  padding: 4px 12px;
-  border-radius: 8px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
   cursor: pointer;
-  font-size: 0.8rem;
-  font-weight: 500;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background 0.15s;
 }
 
-.newChatBtn:hover {
+.panelClose:hover {
   background: rgba(255,255,255,0.35);
 }
 
@@ -132,14 +139,21 @@
 }
 
 @media (max-width: 768px) {
-  .container {
-    padding: 0;
-    background: #ffffff;
+  .floatingPanel {
+    bottom: 0;
+    right: 0;
+    left: 0;
+    width: 100%;
+    height: 72vh;
+    border-radius: 20px 20px 0 0;
+    transform: translateY(24px) scale(1);
   }
 
-  .panel {
-    border-radius: 0;
-    box-shadow: none;
-    border: none;
+  .floatingPanel.panelOpen {
+    transform: translateY(0) scale(1);
+  }
+
+  .sidebar.sidebarOpen {
+    max-height: calc(72vh - 44px - 70px);
   }
 }

--- a/app/spiritual-partner/page.tsx
+++ b/app/spiritual-partner/page.tsx
@@ -7,6 +7,7 @@ import { useChat } from '../contexts/ChatContext';
 import ConversationList from '../components/ConversationList';
 import MessageList from '../components/Chat/MessageList';
 import ChatInput from '../components/Chat/ChatInput';
+import AIFloatingBubble from '../components/Chat/AIFloatingBubble';
 import styles from './page.module.css';
 
 function SpiritualPartnerContent() {
@@ -23,6 +24,7 @@ function SpiritualPartnerContent() {
     setMessages,
   } = useChat();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
   const shouldLoadHistory = useRef(false);
 
   useEffect(() => {
@@ -54,10 +56,11 @@ function SpiritualPartnerContent() {
   if (!user) return null;
 
   return (
-    <div className={styles.container}>
-      <div className={styles.panel}>
+    <>
+      <div className={`${styles.floatingPanel}${chatOpen ? ' ' + styles.panelOpen : ''}`}>
         <div className={styles.panelHeader}>
           <span className={styles.panelTitle}>🙏 靈修伙伴 AI 助手</span>
+          <button className={styles.panelClose} onClick={() => setChatOpen(false)}>✕</button>
         </div>
         <div className={styles.chatWrapper}>
           <div className={`${styles.sidebar}${sidebarOpen ? ' ' + styles.sidebarOpen : ''}`}>
@@ -81,7 +84,8 @@ function SpiritualPartnerContent() {
           </div>
         </div>
       </div>
-    </div>
+      <AIFloatingBubble open={chatOpen} onToggle={() => { setChatOpen(v => !v); setSidebarOpen(false); }} />
+    </>
   );
 }
 

--- a/app/zhiming-yuan/navigator/chat.module.css
+++ b/app/zhiming-yuan/navigator/chat.module.css
@@ -1,7 +1,6 @@
 /* 遠志明耶穌頌 — Floating Chat Widget */
 
 /* ── CSS variables ── */
-.floatingBubble,
 .floatingPanel {
   --chat-bg: #ffffff;
   --chat-sidebar-bg: #f5f5f5;
@@ -18,41 +17,6 @@
   --chat-new-btn-color: #ffffff;
   --chat-send-btn-bg: #1a1a1a;
   --chat-send-btn-hover: #333333;
-}
-
-/* ── Floating bubble button ── */
-.floatingBubble {
-  position: fixed;
-  bottom: 28px;
-  right: 28px;
-  z-index: 1100;
-  width: 67px;
-  height: 67px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #f87171 0%, #b91c1c 100%);
-  box-shadow: 0 4px 20px rgba(185, 28, 28, 0.45), 0 2px 8px rgba(0,0,0,0.18);
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  user-select: none;
-}
-
-.floatingBubble:hover {
-  transform: scale(1.08);
-  box-shadow: 0 6px 28px rgba(185, 28, 28, 0.55), 0 3px 12px rgba(0,0,0,0.22);
-}
-
-.floatingBubble:active {
-  transform: scale(0.96);
-}
-
-.bubbleIcon {
-  width: 33px;
-  height: 33px;
-  display: block;
 }
 
 /* ── Floating chat panel ── */
@@ -179,18 +143,6 @@
 
 /* ── Mobile: full-width bottom sheet ── */
 @media (max-width: 768px) {
-  .floatingBubble {
-    bottom: 20px;
-    right: 20px;
-    width: 60px;
-    height: 60px;
-  }
-
-  .bubbleIcon {
-    width: 30px;
-    height: 30px;
-  }
-
   .floatingPanel {
     bottom: 0;
     right: 0;

--- a/app/zhiming-yuan/page.tsx
+++ b/app/zhiming-yuan/page.tsx
@@ -8,6 +8,7 @@ import { useCredit } from '../contexts/CreditContext';
 import ConversationList from '../components/ConversationList';
 import MessageList from '../components/Chat/MessageList';
 import ChatInput from '../components/Chat/ChatInput';
+import AIFloatingBubble from '../components/Chat/AIFloatingBubble';
 import ReactMarkdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import styles from '../sunday-guide-v2/SundayGuide.module.css';
@@ -440,18 +441,10 @@ function ZhimingYuanContent() {
           </div>
 
           {/* Bubble toggle button */}
-          <button
-            className={chatStyles.floatingBubble}
-            onClick={() => { setChatOpen(v => !v); setSidebarOpen(false); }}
-            title="AI 對話助手"
-          >
-            <svg className={chatStyles.bubbleIcon} viewBox="0 0 24 24" fill="none">
-              <path d="M6 4H18C19.6569 4 21 5.34315 21 7V14C21 15.6569 19.6569 17 18 17H10.5L6.5 21V17H6C4.34315 17 3 15.6569 3 14V7C3 5.34315 4.34315 4 6 4Z" stroke="#ffffff" strokeWidth="1.6" strokeLinejoin="round" />
-              <line x1="7.5" y1="8.4" x2="16.5" y2="8.4" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="11" x2="16.5" y2="11" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-              <line x1="7.5" y1="13.6" x2="13" y2="13.6" stroke="#ffffff" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
-          </button>
+          <AIFloatingBubble
+            open={chatOpen}
+            onToggle={() => { setChatOpen(v => !v); setSidebarOpen(false); }}
+          />
         </>
       )}
     </div>


### PR DESCRIPTION
Covers b886a01 — the Assistants→Responses API migration and 家庭教育/教會助手 additions that came in via the upstream merge — plus 4e02369, this session's floating "AI" toggle-bubble rollout to all 8 assistant pages.